### PR TITLE
Migration to sqlalchemy 1.4.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ cursor = engine.execute(query)
 print([row for row in cursor])
 ```
 
+### Using with Apache Superset
+
+[Apache Superset](https://github.com/apache/superset) starting from [version 1.5](https://github.com/apache/superset/blob/1c1beb653a52c1fcc67a97e539314f138117c6ba/RELEASING/release-notes-1-5/README.md) also supports Kusto database engine spec. \
+When connecting to a new data source you may choose a data source type either KustoSQL or KustoKQL depending on the dialect you want to use.
+
+There are following connection string formats:
+
+```shell
+# KustoSQL
+kustosql+https://<CLUSTER_URL>/<DATABASE>?azure_ad_client_id=<CLIENT_ID>&azure_ad_client_secret=<CLIENT_SECRET>&azure_ad_tenant_id=<TENANT_ID>&msi=False
+
+# KustoKQL
+kustokql+https://<CLUSTER_URL>/<DATABASE>?azure_ad_client_id=<CLIENT_ID>&azure_ad_client_secret=<CLIENT_SECRET>&azure_ad_tenant_id=<TENANT_ID>&msi=False
+```
+> Important notice on package version compatibility. \
+> Apache Superset stable releases 1.5 and 2.0 dependent on `sqlalchemy==1.3.24`. If you want to use `sqlalchemy-kusto` with these versions you need to install version `1.*` of the package.
+> 
+> Current `master` branch of the `apache/superset` dependent on `sqlalchemy==1.4.36`. If you want to use `sqlalchemy-kusto` with the latest unstable version of `apache/superset`, you need to install version `2.*` of the package.
+
 ## Contributing
 
 Please see the [CONTRIBUTING.md](.github/CONTRIBUTING.md) for development setup and contributing process guidelines.

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import find_packages, setup
 
 NAME = "sqlalchemy-kusto"
 DESCRIPTION = "Azure Data Explorer (Kusto) dialect for SQLAlchemy"
-VERSION = "1.1.0"
+VERSION = "2.0.0"
 
 REQUIREMENTS = [
-    "azure-kusto-data==2.1.1",
-    "sqlalchemy==1.3.24",
+    "azure-kusto-data>=3.1.3",
+    "sqlalchemy==1.4.36",
 ]
 EXTRAS = {
     "dev": [

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ DESCRIPTION = "Azure Data Explorer (Kusto) dialect for SQLAlchemy"
 VERSION = "2.0.0"
 
 REQUIREMENTS = [
-    "azure-kusto-data>=3.1.3",
-    "sqlalchemy==1.4.36",
-    "typing-extensions==3.10.0.0",
+    "azure-kusto-data==3.*",
+    "sqlalchemy==1.4.*",
+    "typing-extensions~=3.10",
 ]
 EXTRAS = {
     "dev": [

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ VERSION = "2.0.0"
 REQUIREMENTS = [
     "azure-kusto-data>=3.1.3",
     "sqlalchemy==1.4.36",
+    "typing-extensions==3.10.0.0",
 ]
 EXTRAS = {
     "dev": [

--- a/sqlalchemy_kusto/dialect_base.py
+++ b/sqlalchemy_kusto/dialect_base.py
@@ -124,7 +124,7 @@ class KustoBaseDialect(default.DefaultDialect, ABC):
         result = connection.execute(".show materialized-views | project Name")
         return [row.Name for row in result]
 
-    def get_pk_constraint(self, conn: Connection, table_name: str, schema: Optional[str] = None, **kw):
+    def get_pk_constraint(self, connection: Connection, table_name: str, schema: Optional[str] = None, **kw):
         return {"constrained_columns": [], "name": None}
 
     def get_foreign_keys(self, connection, table_name, schema=None, **kwargs):

--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -51,12 +51,12 @@ class KustoKqlCompiler(compiler.SQLCompiler):
     ):
         logger.debug("Incoming query: %s", select)
 
-        if len(select.froms) != 1:
+        if len(select.get_final_froms()) != 1:
             raise NotSupportedError('Only single "select from" query is supported in kql compiler')
 
         compiled_query_lines = []
 
-        from_object = select.froms[0]
+        from_object = select.get_final_froms()[0]
         if hasattr(from_object, "element"):
             query = self._get_most_inner_element(from_object.element)
             (main, lets) = self._extract_let_statements(query.text)
@@ -178,3 +178,4 @@ class KustoKqlHttpsDialect(KustoBaseDialect):
     name = "kustokql"
     statement_compiler = KustoKqlCompiler
     preparer = KustoKqlIdentifierPreparer
+    supports_statement_cache = True

--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -164,7 +164,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             - MyTable                     -> MyTable
         """
 
-        pattern = r"^([a-zA-Z0-9]+\b|\"[a-zA-Z0-9 \-_.]+\")?\.?([a-zA-Z0-9]+\b|\"[a-zA-Z0-9 \-_.]+\")"
+        pattern = r"^\[?([a-zA-Z0-9]+\b|\"[a-zA-Z0-9 \-_.]+\")?\]?\.?\[?([a-zA-Z0-9]+\b|\"[a-zA-Z0-9 \-_.]+\")\]?"
         match = re.search(pattern, query)
 
         if not match or not match.group(1):

--- a/sqlalchemy_kusto/dialect_sql.py
+++ b/sqlalchemy_kusto/dialect_sql.py
@@ -34,3 +34,6 @@ class KustoSqlCompiler(compiler.SQLCompiler):
 class KustoSqlHttpsDialect(KustoBaseDialect):
     name = "kustosql"
     statement_compiler = KustoSqlCompiler
+    # For some reason supports_statement_cache doesn't work when defined in the KustoBaseDialect.
+    # Need to investigate why it happens.
+    supports_statement_cache = True

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -22,7 +22,7 @@ def test_compiler_with_projection():
 
     query_compiled = str(query.compile(engine)).replace("\n", "")
     query_expected = (
-        "let virtual_table = (logs | take 10);"
+        'let virtual_table = (["logs"] | take 10);'
         "virtual_table"
         "| project id = Id, tId = TypeId, Type"
         "| take __[POSTCOMPILE_param_1]"
@@ -42,7 +42,7 @@ def test_compiler_with_star():
     query = query.limit(10)
 
     query_compiled = str(query.compile(engine)).replace("\n", "")
-    query_expected = "let virtual_table = (logs | take 10);" "virtual_table" "| take __[POSTCOMPILE_param_1]"
+    query_expected = 'let virtual_table = (["logs"] | take 10);' "virtual_table" "| take __[POSTCOMPILE_param_1]"
 
     assert query_compiled == query_expected
 
@@ -50,7 +50,7 @@ def test_compiler_with_star():
 def test_select_from_text():
     query = select([column("Field1"), column("Field2")]).select_from(text("logs")).limit(100)
     query_compiled = str(query.compile(engine, compile_kwargs={"literal_binds": True})).replace("\n", "")
-    query_expected = "logs" "| project Field1, Field2" "| take 100"
+    query_expected = '["logs"]' "| project Field1, Field2" "| take 100"
 
     assert query_compiled == query_expected
 
@@ -67,7 +67,7 @@ def test_use_table():
     query = stream.select().limit(5)
     query_compiled = str(query.compile(engine)).replace("\n", "")
 
-    query_expected = "logs" "| project Field1, Field2" "| take __[POSTCOMPILE_param_1]"
+    query_expected = '["logs"]' "| project Field1, Field2" "| take __[POSTCOMPILE_param_1]"
     assert query_compiled == query_expected
 
 
@@ -78,7 +78,7 @@ def test_limit():
 
     query_compiled = str(query.compile(engine, compile_kwargs={"literal_binds": True})).replace("\n", "")
 
-    query_expected = "let inner_qry = (logs);" "inner_qry" "| take 5"
+    query_expected = 'let inner_qry = (["logs"]);' "inner_qry" "| take 5"
 
     assert query_compiled == query_expected
 
@@ -98,7 +98,7 @@ def test_select_count():
     query_compiled = str(query.compile(engine, compile_kwargs={"literal_binds": True})).replace("\n", "")
 
     query_expected = (
-        "let inner_qry = (logs);"
+        'let inner_qry = (["logs"]);'
         "inner_qry"
         "| where Field1 > 1 and Field2 < 2"
         "| summarize count = count()"
@@ -117,7 +117,7 @@ def test_select_with_let():
     query_expected = (
         "let x = 5;"
         "let y = 3;"
-        "let inner_qry = (MyTable | where Field1 == x and Field2 == y);"
+        'let inner_qry = (["MyTable"] | where Field1 == x and Field2 == y);'
         "inner_qry"
         "| take 5"
     )
@@ -140,7 +140,7 @@ def test_quotes():
 
     # fmt: off
     query_expected = (
-        "logs"
+        '["logs"]'
         '| project ["Field1"], ["Field2"]'
         "| take __[POSTCOMPILE_param_1]"
     )
@@ -152,13 +152,13 @@ def test_quotes():
 @pytest.mark.parametrize(
     "schema_name,table_name,expected_table_name",
     [
-        ("schema", "table", 'database("schema").table'),
-        ("schema", '"table.name"', 'database("schema")."table.name"'),
-        ('"schema.name"', "table", 'database("schema.name").table'),
-        ('"schema.name"', '"table.name"', 'database("schema.name")."table.name"'),
-        ('"schema name"', '"table name"', 'database("schema name")."table name"'),
-        (None, '"table.name"', '"table.name"'),
-        (None, "MyTable", "MyTable"),
+        ("schema", "table", 'database("schema").["table"]'),
+        ("schema", '"table.name"', 'database("schema").["table.name"]'),
+        ('"schema.name"', "table", 'database("schema.name").["table"]'),
+        ('"schema.name"', '"table.name"', 'database("schema.name").["table.name"]'),
+        ('"schema name"', '"table name"', 'database("schema name").["table name"]'),
+        (None, '"table.name"', '["table.name"]'),
+        (None, "MyTable", '["MyTable"]'),
     ],
 )
 def test_schema_from_metadata(table_name: str, schema_name: str, expected_table_name: str):
@@ -178,14 +178,14 @@ def test_schema_from_metadata(table_name: str, schema_name: str, expected_table_
 @pytest.mark.parametrize(
     "query_table_name,expected_table_name",
     [
-        ("schema.table", 'database("schema").table'),
-        ('schema."table.name"', 'database("schema")."table.name"'),
-        ('"schema.name".table', 'database("schema.name").table'),
-        ('"schema.name"."table.name"', 'database("schema.name")."table.name"'),
-        ('"schema name"."table name"', 'database("schema name")."table name"'),
-        ('"table.name"', '"table.name"'),
-        ("MyTable", "MyTable"),
-        ('["schema"].["table"]', 'database("schema")."table"'),
+        ("schema.table", 'database("schema").["table"]'),
+        ('schema."table.name"', 'database("schema").["table.name"]'),
+        ('"schema.name".table', 'database("schema.name").["table"]'),
+        ('"schema.name"."table.name"', 'database("schema.name").["table.name"]'),
+        ('"schema name"."table name"', 'database("schema name").["table name"]'),
+        ('"table.name"', '["table.name"]'),
+        ("MyTable", '["MyTable"]'),
+        ('["schema"].["table"]', 'database("schema").["table"]'),
         ('["table"]', '["table"]'),
     ],
 )

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -185,6 +185,8 @@ def test_schema_from_metadata(table_name: str, schema_name: str, expected_table_
         ('"schema name"."table name"', 'database("schema name")."table name"'),
         ('"table.name"', '"table.name"'),
         ("MyTable", "MyTable"),
+        ('["schema"].["table"]', 'database("schema")."table"'),
+        ('["table"]', '["table"]'),
     ],
 )
 def test_schema_from_query(query_table_name: str, expected_table_name: str):

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -25,7 +25,7 @@ def test_compiler_with_projection():
         "let virtual_table = (logs | take 10);"
         "virtual_table"
         "| project id = Id, tId = TypeId, Type"
-        "| take %(param_1)s"
+        "| take __[POSTCOMPILE_param_1]"
     )
 
     assert query_compiled == query_expected
@@ -42,7 +42,7 @@ def test_compiler_with_star():
     query = query.limit(10)
 
     query_compiled = str(query.compile(engine)).replace("\n", "")
-    query_expected = "let virtual_table = (logs | take 10);" "virtual_table" "| take %(param_1)s"
+    query_expected = "let virtual_table = (logs | take 10);" "virtual_table" "| take __[POSTCOMPILE_param_1]"
 
     assert query_compiled == query_expected
 
@@ -67,7 +67,7 @@ def test_use_table():
     query = stream.select().limit(5)
     query_compiled = str(query.compile(engine)).replace("\n", "")
 
-    query_expected = "logs" "| project Field1, Field2" "| take %(param_1)s"
+    query_expected = "logs" "| project Field1, Field2" "| take __[POSTCOMPILE_param_1]"
     assert query_compiled == query_expected
 
 
@@ -142,7 +142,7 @@ def test_quotes():
     query_expected = (
         "logs"
         '| project ["Field1"], ["Field2"]'
-        "| take %(param_1)s"
+        "| take __[POSTCOMPILE_param_1]"
     )
     # fmt: on
 
@@ -171,7 +171,7 @@ def test_schema_from_metadata(table_name: str, schema_name: str, expected_table_
 
     query_compiled = str(query.compile(engine)).replace("\n", "")
 
-    query_expected = f"{expected_table_name}| take %(param_1)s"
+    query_expected = f"{expected_table_name}| take __[POSTCOMPILE_param_1]"
     assert query_compiled == query_expected
 
 


### PR DESCRIPTION
Upgrade `sqlalchemy` to 1.4.*.
The master branch of [apache/superset](https://github.com/apache/superset/blob/master/requirements/base.txt#L264) upgraded `sqlalchemy` to 1.4.36, so we also upgrade our library dependencies.
More details in the [discussion in apache/superset](https://github.com/apache/superset/discussions/18397#discussioncomment-3512173) repo.

Additionally, `azure-kusto-data` upgraded to the latest version and `typing-extensions` is explicitly defined in the dependencies.

Closes #10.