### PR TITLE
Relaxed dependency version of typing-extensions to >= 3.10.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ check: # Run formatters and linters
 	@echo "Running checkers..."
 
 	@echo "\n1. Run $(GREEN_ITALIC)isort$(DEFAULT) to order imports."
-	$(PYTHON) -m isort .
+	$(PYTHON) -m isort --profile black .
 
 	@echo "\n2. Run $(GREEN_ITALIC)black$(DEFAULT) to format code."
 	$(PYTHON) -m black .

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = "2.0.0"
 REQUIREMENTS = [
     "azure-kusto-data==3.*",
     "sqlalchemy==1.4.*",
-    "typing-extensions~=3.10",
+    "typing-extensions>=3.10",
 ]
 EXTRAS = {
     "dev": [

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ EXTRAS = {
     "dev": [
         "black>=21.12b0",
         "isort>=5.10.1",
-        "mypy>=0.9.30",
-        "pylint>=2.12.2",
+        "mypy==0.971",
+        "pylint==2.15.0",
         "pytest>=6.2.5",
         "python-dotenv>=0.19.2",
     ]


### PR DESCRIPTION
This PR is induced by the issue https://github.com/apache/superset/issues/25032.
To be compatible with further versions of Apache Superset we need to relax the dependency version to > 3.10 (4 actually).