### PR TITLE
BugFix/Handle Column Alias with Op Chars

### DIFF
--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -364,16 +364,19 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         # Remove surrounding spaces
         # Handle mathematical operations (wrap only the column part before operators)
         # Find the position of the first operator or space that separates the column name
-        for operator in ["/", "+", "-", "*"]:
-            if operator in name:
-                # Split the name at the first operator and wrap the left part
-                parts = name.split(operator, 1)
-                # Remove quotes if they exist at the edges
-                col_part = parts[0].strip()
-                if col_part.startswith('"') and col_part.endswith('"'):
-                    return f'["{col_part[1:-1].strip()}"] {operator} {parts[1].strip()}'
-                return f'["{col_part}"] {operator} {parts[1].strip()}'  # Wrap the column part
+        if not is_alias:
+            for operator in ["/", "+", "-", "*"]:
+                if operator in name:
+                    # Split the name at the first operator and wrap the left part
+                    parts = name.split(operator, 1)
+                    # Remove quotes if they exist at the edges
+                    col_part = parts[0].strip()
+                    if col_part.startswith('"') and col_part.endswith('"'):
+                        col_part = col_part[1:-1].strip()
+                    col_part = col_part.replace('"', '\\"')
+                    return f'["{col_part}"] {operator} {parts[1].strip()}'  # Wrap the column part
         # No operators found, just wrap the entire name
+        name = name.replace('"', '\\"')
         return f'["{name}"]'
 
     @staticmethod

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -409,13 +409,13 @@ def test_limit():
 
 def test_select_count():
     kql_query = "logs"
-    column_count = literal_column("count(*)").label("count")
+    column_count = literal_column("count(*)").label("total-count")
     query = (
         select([column_count])
         .select_from(TextAsFrom(text(kql_query), ["*"]).alias("inner_qry"))
         .where(text("Field1 > 1"))
         .where(text("Field2 < 2"))
-        .order_by(text("count DESC"))
+        .order_by(text("total-count DESC"))
         .limit(5)
     )
 
@@ -427,9 +427,9 @@ def test_select_count():
         'let inner_qry = (["logs"]);'
         "inner_qry"
         "| where Field1 > 1 and Field2 < 2"
-        '| summarize ["count"] = count() '
-        '| project ["count"]'
-        '| order by ["count"] desc'
+        '| summarize ["total-count"] = count() '
+        '| project ["total-count"]'
+        '| order by ["total-count"] desc'
         "| take 5"
     )
 


### PR DESCRIPTION
Don't split column aliases on operator characters, and escape any double quote before wrapping with double quotes.

Updated unit test to identify and protect against this issue.