### PR TITLE
fix: Handle COUNT(*) as column name in KQL dialect

### DIFF
--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -268,9 +268,9 @@ class KustoKqlCompiler(compiler.SQLCompiler):
 
         # Process columns if they exist
         if columns is not None:
-            summarize_columns = set()
-            extend_columns = set()
-            projection_columns = []
+            summarize_columns: set[str] = set()
+            extend_columns: set[str] = set()
+            projection_columns: list[str] = []
             has_aggregates = False
 
             # Process each column (except *)

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -374,7 +374,10 @@ def test_escape_and_quote_columns():
     )
     # Test COUNT(*) handling
     assert KustoKqlCompiler._escape_and_quote_columns("COUNT(*)") == "count()"
-    assert KustoKqlCompiler._escape_and_quote_columns("COUNT(*)", is_alias=True) == '["COUNT(*)"]'
+    assert (
+        KustoKqlCompiler._escape_and_quote_columns("COUNT(*)", is_alias=True)
+        == '["COUNT(*)"]'
+    )
 
 
 def test_use_table():


### PR DESCRIPTION
This commit fixes an issue where using COUNT(*) as a column name in Apache 
Superset's drill-by functionality would result in a 'Semantic error: 
Unsupported calculated column name COUNT(*)' error.

Changes:
- Add special handling for COUNT(*) as a column name
- Refactor _get_projection_or_summarize method to reduce complexity
- Add helper methods for processing columns and checking for COUNT(*)
- Differentiate between literal_column and regular column usage of COUNT(*)
- Add special handling for the case where there are WHERE clauses
- Add handling for quoted \"COUNT(*)\" expressions
- Add test case to verify the fix works correctly
- Fix linting issues and format code according to Black style guidelines

The fix ensures that COUNT(*) is properly translated to count() when used as 
a function and properly quoted as [\"COUNT(*)\"] when used as a column name or 
alias, which resolves the error in Superset's drill-by functionality."