### PR TITLE
Users/ramacg/feature/update predicate order

### DIFF
--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -81,6 +81,8 @@ conditional_aggregates = {
 
 AGGREGATE_PATTERN = r"(\w+)\s*\(\s*(DISTINCT|distinct\s*)?\(?\s*(\*|\[?\"?\'?\w+\"?\]?)\s*(,.+)*\)?\s*\)"
 
+min_call_parts = 2  # Minimum parts in a conditional aggregate call when split by '(' (e.g., countif(xyz) has 2 parts)
+
 
 class UniversalSet:
     def __contains__(self, item):
@@ -254,7 +256,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             "summarize": summarize_statement,
             "project": project_statement,
             "sort": sort_statement,
-            "predicate_if": " and ".join(where_if_cols) if where_if_cols else "",
+            "predicate_if": " or ".join(where_if_cols) if where_if_cols else "",
         }
 
     def _process_columns(self, columns) -> dict[str, Any]:
@@ -271,19 +273,17 @@ class KustoKqlCompiler(compiler.SQLCompiler):
 
             kql_agg = self._extract_maybe_agg_column_parts(column_name)
             is_conditional_aggregate = self._is_conditional_aggregate(column_name)
-
+            extract_base = (kql_agg if kql_agg else column_name).replace("\n", "")
             if is_conditional_aggregate:
                 has_aggregates = True
-                predicate = self._extract_predicate_from_conditional_agg(
-                    column_name, kql_agg
-                )
+                cols, predicate = self._extract_columns_and_predicate(extract_base)
                 if predicate:
                     where_if_cols.add(predicate)
 
-            if kql_agg:
+            if kql_agg or is_conditional_aggregate:
                 has_aggregates = True
                 summarize_columns.add(
-                    self._build_column_projection(kql_agg, column_alias)
+                    self._build_column_projection(extract_base, column_alias)
                 )
             elif column_alias and column_alias != column_name:
                 extend_columns.add(
@@ -304,23 +304,13 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             "where_if_cols": where_if_cols,
         }
 
-    def _is_conditional_aggregate(self, column_name: str) -> bool:
+    @staticmethod
+    def _is_conditional_aggregate(column_name: str) -> bool:
         """Check if column_name contains a conditional aggregate function."""
         for fn in conditional_aggregates:
             if column_name.lower().__contains__(fn):
                 return True
         return False
-
-    def _extract_predicate_from_conditional_agg(
-        self, column_name: str, kql_agg: str | None
-    ) -> str | None:
-        """Extract predicate from conditional aggregate function."""
-        parts = (
-            self._extract_columns_and_predicate(kql_agg)
-            if kql_agg
-            else self._extract_columns_and_predicate(column_name)
-        )
-        return parts[1] if parts and parts[1] else None
 
     @staticmethod
     def _extract_maybe_agg_column_parts(column_name) -> str | None:
@@ -652,7 +642,6 @@ class KustoKqlCompiler(compiler.SQLCompiler):
 
         Examples:
             - schema.table                -> database("schema").["table"]
-            - schema."table.name"         -> database("schema").{"table.name"]
             - "schema.name".table         -> database("schema.name").["table"]
             - "schema.name"."table.name"  -> database("schema.name").["table.name"]
             - "schema name"."table name"  -> database("schema name").["table name"]
@@ -720,63 +709,25 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         return return_value
 
     @staticmethod
-    def _extract_columns_and_predicate(call: str) -> tuple[list[str], str | None]:
-        """
-        Given a function call string like:
-          covariancepif(x, y, x % 3 == 0)
-          countif(DamageCrops >0)
-          sumif(a,DamageCrops >0)
-        Returns (columns: list[str], predicate: str|None).
-        """
-        # Find the argument list
-        m = re.match(r"(\w+)\s*\((.*)\)", call)
-        if not m:
-            return [], None
-        args_str = m.group(2)
-        # Split args, respecting nested parentheses
-        args = []
-        current = ""
-        depth = 0
-        for c in args_str:
-            if c == "," and depth == 0:
-                args.append(current.strip())
-                current = ""
+    def _extract_columns_and_predicate(
+        extract_base: str,
+    ) -> tuple[list[str], str | None]:
+        call_parts = extract_base.split("(")
+        if call_parts and len(call_parts) >= min_call_parts:
+            function_name = call_parts[0].strip()
+            if function_name == "countif":
+                parts_match = re.search(r"\((.*)\)", extract_base)
+                if not parts_match:
+                    return [], None
+                predicate = parts_match.group(1).strip()
+                return [], predicate
             else:
-                if c == "(":
-                    depth += 1
-                elif c == ")":
-                    depth -= 1
-                current += c
-        if current.strip():
-            args.append(current.strip())
-        # Predicate detection: look for comparison operators
-        predicate_ops = [
-            "==",
-            "!=",
-            ">=",
-            "<=",
-            ">",
-            "<",
-            " in ",
-            " not in ",
-            " is ",
-            " like ",
-            " between ",
-        ]
-
-        def is_predicate(s):
-            return any(op in s for op in predicate_ops)
-
-        if not args:
-            return [], None
-        # If only one arg and it's a predicate
-        if len(args) == 1 and is_predicate(args[0]):
-            return [], args[0]
-        # If last arg is a predicate
-        if is_predicate(args[-1]):
-            return args[:-1], args[-1]
-        # Otherwise, no predicate
-        return args, None
+                match = re.search(r"(\w+)\s*\(\s*([^,]+)\s*,\s*(.+)\)", extract_base)
+                if not match:
+                    return [], None
+                function_name, columns, predicate = match.groups()
+                return columns.split(","), predicate
+        return [], None
 
 
 class KustoKqlHttpsDialect(KustoBaseDialect):

--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -141,6 +141,10 @@ class KustoKqlCompiler(compiler.SQLCompiler):
                     where_clause_reformatted
                 )
                 compiled_query_lines.append(f"| where {converted_where_clause}")
+        if projections_parts_dict.get("predicate_if"):
+            compiled_query_lines.append(
+                f"| where {projections_parts_dict.pop('predicate_if')}"
+            )
 
         if "extend" in projections_parts_dict:
             compiled_query_lines.append(projections_parts_dict.pop("extend"))
@@ -211,6 +215,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         #     - Do the columns have aliases ? --Yes---> Extend with aliases
         #                |
         #                N---> Add to projection
+        where_if_cols = set()
         if columns is not None:
             summarize_columns = set()
             extend_columns = set()
@@ -226,6 +231,11 @@ class KustoKqlCompiler(compiler.SQLCompiler):
                     summarize_columns.add(
                         self._build_column_projection(kql_agg, column_alias)
                     )
+                if kql_agg and str(kql_agg).__contains__("if("):
+                    #extract the part within the braces
+                    parts = KustoKqlCompiler._extract_columns_and_predicate(kql_agg)
+                    if parts and parts[1]:
+                        where_if_cols.add(parts[1])
                 # No group by clause
                 # Do the columns have aliases ?
                 # Add additional and to handle case where : SELECT column_name as column_name
@@ -267,14 +277,13 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             "summarize": summarize_statement,
             "project": project_statement,
             "sort": sort_statement,
+            "predicate_if": " and ".join(where_if_cols) if where_if_cols else "",
         }
 
     @staticmethod
     def _extract_maybe_agg_column_parts(column_name) -> str | None:
         match_agg_cols = re.match(AGGREGATE_PATTERN, column_name, re.IGNORECASE)
         if match_agg_cols and match_agg_cols.groups():
-            # Check if the aggregate function is count_distinct. This is case from superset
-            # where we can use count(distinct or count_distinct)
             aggregate_func, distinct_keyword, agg_column_name, extra_params = (
                 match_agg_cols.groups()
             )
@@ -599,7 +608,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
 
         Examples:
             - schema.table                -> database("schema").["table"]
-            - schema."table.name"         -> database("schema").{"table.name"]
+            - schema."table.name"         -> database("schema").{"table.name"}
             - "schema.name".table         -> database("schema.name").["table"]
             - "schema.name"."table.name"  -> database("schema.name").["table.name"]
             - "schema name"."table name"  -> database("schema name").["table name"]
@@ -665,6 +674,52 @@ class KustoKqlCompiler(compiler.SQLCompiler):
                 f"{aggregation_function}({column_name_escaped}{extra_params})"
             )
         return return_value
+
+    @staticmethod
+    def _extract_columns_and_predicate(call: str):
+        """
+        Given a function call string like:
+          covariancepif(x, y, x % 3 == 0)
+          countif(DamageCrops >0)
+          sumif(a,DamageCrops >0)
+        Returns (columns: list[str], predicate: str|None)
+        """
+        import re
+        # Find the argument list
+        m = re.match(r"(\w+)\s*\((.*)\)", call)
+        if not m:
+            return [], None
+        args_str = m.group(2)
+        # Split args, respecting nested parentheses
+        args = []
+        current = ''
+        depth = 0
+        for c in args_str:
+            if c == ',' and depth == 0:
+                args.append(current.strip())
+                current = ''
+            else:
+                if c == '(':
+                    depth += 1
+                elif c == ')':
+                    depth -= 1
+                current += c
+        if current.strip():
+            args.append(current.strip())
+        # Predicate detection: look for comparison operators
+        predicate_ops = ['==', '!=', '>=', '<=', '>', '<', ' in ', ' not in ', ' is ', ' like ', ' between ']
+        def is_predicate(s):
+            return any(op in s for op in predicate_ops)
+        if not args:
+            return [], None
+        # If only one arg and it's a predicate
+        if len(args) == 1 and is_predicate(args[0]):
+            return [], args[0]
+        # If last arg is a predicate
+        if is_predicate(args[-1]):
+            return args[:-1], args[-1]
+        # Otherwise, no predicate
+        return args, None
 
 
 class KustoKqlHttpsDialect(KustoBaseDialect):

--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -235,7 +235,9 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             # group by columns
             by_columns = self._group_by(group_by_cols)
             if has_aggregates or bool(by_columns):
-                summarize_statement = f"| summarize {', '.join(summarize_columns)} "
+                summarize_statement = (
+                    f"| summarize {', '.join(sorted(summarize_columns))} "
+                )
                 if by_columns:
                     summarize_statement = (
                         f"{summarize_statement} by {', '.join(by_columns)}"
@@ -256,7 +258,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             "summarize": summarize_statement,
             "project": project_statement,
             "sort": sort_statement,
-            "predicate_if": " or ".join(where_if_cols) if where_if_cols else "",
+            "predicate_if": " or ".join(sorted(where_if_cols)) if where_if_cols else "",
         }
 
     def _process_columns(self, columns) -> dict[str, Any]:

--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from typing import Any
 
 from sqlalchemy import Column, exc, sql
 from sqlalchemy.sql import compiler, operators, selectable
@@ -219,7 +220,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         extend_statement = ""
         project_statement = ""
         has_aggregates = False
-        where_if_cols = set()
+        where_if_cols: set[str] = set()
 
         if columns is not None:
             column_data = self._process_columns(columns)
@@ -234,7 +235,9 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             if has_aggregates or bool(by_columns):
                 summarize_statement = f"| summarize {', '.join(summarize_columns)} "
                 if by_columns:
-                    summarize_statement = f"{summarize_statement} by {', '.join(by_columns)}"
+                    summarize_statement = (
+                        f"{summarize_statement} by {', '.join(by_columns)}"
+                    )
             if extend_columns:
                 extend_statement = f"| extend {', '.join(sorted(extend_columns))}"
             project_statement = (
@@ -254,7 +257,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             "predicate_if": " and ".join(where_if_cols) if where_if_cols else "",
         }
 
-    def _process_columns(self, columns) -> dict[str, any]:
+    def _process_columns(self, columns) -> dict[str, Any]:
         """Process columns and return data structures for summarize, extend, and project."""
         summarize_columns = set()
         extend_columns = set()
@@ -271,7 +274,9 @@ class KustoKqlCompiler(compiler.SQLCompiler):
 
             if is_conditional_aggregate:
                 has_aggregates = True
-                predicate = self._extract_predicate_from_conditional_agg(column_name, kql_agg)
+                predicate = self._extract_predicate_from_conditional_agg(
+                    column_name, kql_agg
+                )
                 if predicate:
                     where_if_cols.add(predicate)
 
@@ -306,7 +311,9 @@ class KustoKqlCompiler(compiler.SQLCompiler):
                 return True
         return False
 
-    def _extract_predicate_from_conditional_agg(self, column_name: str, kql_agg: str | None) -> str | None:
+    def _extract_predicate_from_conditional_agg(
+        self, column_name: str, kql_agg: str | None
+    ) -> str | None:
         """Extract predicate from conditional aggregate function."""
         parts = (
             self._extract_columns_and_predicate(kql_agg)

--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -65,6 +65,19 @@ kql_aggregates = {
     "varianceif",
     "variancep",
 }
+conditional_aggregates = {
+    "minif",
+    "sumif",
+    "maxif",
+    "avgif",
+    "dcountif",
+    "stdevif",
+    "varianceif",
+    "countif",  # No arity
+    "covariancepif",  # 3 arity
+    "covarianceif",  # 3 arity
+}
+
 AGGREGATE_PATTERN = r"(\w+)\s*\(\s*(DISTINCT|distinct\s*)?\(?\s*(\*|\[?\"?\'?\w+\"?\]?)\s*(,.+)*\)?\s*\)"
 
 
@@ -141,6 +154,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
                     where_clause_reformatted
                 )
                 compiled_query_lines.append(f"| where {converted_where_clause}")
+
         if projections_parts_dict.get("predicate_if"):
             compiled_query_lines.append(
                 f"| where {projections_parts_dict.pop('predicate_if')}"
@@ -205,6 +219,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         extend_statement = ""
         project_statement = ""
         has_aggregates = False
+        where_if_cols = set()
         # The following is the logic
         # With Columns :
         #     - Do we have a group by clause ? --Yes---> Do we have aggregate columns ? --Yes--> Summarize new column(s)
@@ -215,10 +230,10 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         #     - Do the columns have aliases ? --Yes---> Extend with aliases
         #                |
         #                N---> Add to projection
-        where_if_cols = set()
         if columns is not None:
             summarize_columns = set()
             extend_columns = set()
+            aggregate_func = None
             projection_columns = []
             for column in [c for c in columns if c.name != "*"]:
                 column_name, column_alias = self._extract_column_name_and_alias(column)
@@ -226,16 +241,29 @@ class KustoKqlCompiler(compiler.SQLCompiler):
                 # Do we have a group by clause ?
                 # Do we have aggregate columns ?
                 kql_agg = self._extract_maybe_agg_column_parts(column_name)
+                is_conditional_aggregate = False
+
+                for fn in conditional_aggregates:
+                    if column_name.lower().__contains__(fn):
+                        is_conditional_aggregate = True
+                        break
+
+                if is_conditional_aggregate:
+                    has_aggregates = True
+                    # extract the part within the braces. The conditional is for cases with multi arity functions
+                    # to extract kql_agg from the regex or from the column_name itself
+                    parts = (
+                        self._extract_columns_and_predicate(kql_agg)
+                        if kql_agg
+                        else self._extract_columns_and_predicate(column_name)
+                    )
+                    if parts and parts[1]:
+                        where_if_cols.add(parts[1])
                 if kql_agg:
                     has_aggregates = True
                     summarize_columns.add(
                         self._build_column_projection(kql_agg, column_alias)
                     )
-                if kql_agg and str(kql_agg).__contains__("if("):
-                    #extract the part within the braces
-                    parts = KustoKqlCompiler._extract_columns_and_predicate(kql_agg)
-                    if parts and parts[1]:
-                        where_if_cols.add(parts[1])
                 # No group by clause
                 # Do the columns have aliases ?
                 # Add additional and to handle case where : SELECT column_name as column_name
@@ -284,6 +312,8 @@ class KustoKqlCompiler(compiler.SQLCompiler):
     def _extract_maybe_agg_column_parts(column_name) -> str | None:
         match_agg_cols = re.match(AGGREGATE_PATTERN, column_name, re.IGNORECASE)
         if match_agg_cols and match_agg_cols.groups():
+            # Check if the aggregate function is count_distinct. This is case from superset
+            # where we can use count(distinct or count_distinct)
             aggregate_func, distinct_keyword, agg_column_name, extra_params = (
                 match_agg_cols.groups()
             )
@@ -608,7 +638,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
 
         Examples:
             - schema.table                -> database("schema").["table"]
-            - schema."table.name"         -> database("schema").{"table.name"}
+            - schema."table.name"         -> database("schema").{"table.name"]
             - "schema.name".table         -> database("schema.name").["table"]
             - "schema.name"."table.name"  -> database("schema.name").["table.name"]
             - "schema name"."table name"  -> database("schema name").["table name"]
@@ -685,6 +715,7 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         Returns (columns: list[str], predicate: str|None)
         """
         import re
+
         # Find the argument list
         m = re.match(r"(\w+)\s*\((.*)\)", call)
         if not m:
@@ -692,24 +723,38 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         args_str = m.group(2)
         # Split args, respecting nested parentheses
         args = []
-        current = ''
+        current = ""
         depth = 0
         for c in args_str:
-            if c == ',' and depth == 0:
+            if c == "," and depth == 0:
                 args.append(current.strip())
-                current = ''
+                current = ""
             else:
-                if c == '(':
+                if c == "(":
                     depth += 1
-                elif c == ')':
+                elif c == ")":
                     depth -= 1
                 current += c
         if current.strip():
             args.append(current.strip())
         # Predicate detection: look for comparison operators
-        predicate_ops = ['==', '!=', '>=', '<=', '>', '<', ' in ', ' not in ', ' is ', ' like ', ' between ']
+        predicate_ops = [
+            "==",
+            "!=",
+            ">=",
+            "<=",
+            ">",
+            "<",
+            " in ",
+            " not in ",
+            " is ",
+            " like ",
+            " between ",
+        ]
+
         def is_predicate(s):
             return any(op in s for op in predicate_ops)
+
         if not args:
             return [], None
         # If only one arg and it's a predicate

--- a/sqlalchemy_kusto/dialect_kql.py
+++ b/sqlalchemy_kusto/dialect_kql.py
@@ -220,75 +220,21 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         project_statement = ""
         has_aggregates = False
         where_if_cols = set()
-        # The following is the logic
-        # With Columns :
-        #     - Do we have a group by clause ? --Yes---> Do we have aggregate columns ? --Yes--> Summarize new column(s)
-        #                |                                   |                                        with by clause
-        #                N                                   N --> Add to projection
-        #                |
-        #                |
-        #     - Do the columns have aliases ? --Yes---> Extend with aliases
-        #                |
-        #                N---> Add to projection
+
         if columns is not None:
-            summarize_columns = set()
-            extend_columns = set()
-            aggregate_func = None
-            projection_columns = []
-            for column in [c for c in columns if c.name != "*"]:
-                column_name, column_alias = self._extract_column_name_and_alias(column)
-                column_alias = self._escape_and_quote_columns(column_alias, True)
-                # Do we have a group by clause ?
-                # Do we have aggregate columns ?
-                kql_agg = self._extract_maybe_agg_column_parts(column_name)
-                is_conditional_aggregate = False
+            column_data = self._process_columns(columns)
+            summarize_columns = column_data["summarize_columns"]
+            extend_columns = column_data["extend_columns"]
+            projection_columns = column_data["projection_columns"]
+            has_aggregates = column_data["has_aggregates"]
+            where_if_cols = column_data["where_if_cols"]
 
-                for fn in conditional_aggregates:
-                    if column_name.lower().__contains__(fn):
-                        is_conditional_aggregate = True
-                        break
-
-                if is_conditional_aggregate:
-                    has_aggregates = True
-                    # extract the part within the braces. The conditional is for cases with multi arity functions
-                    # to extract kql_agg from the regex or from the column_name itself
-                    parts = (
-                        self._extract_columns_and_predicate(kql_agg)
-                        if kql_agg
-                        else self._extract_columns_and_predicate(column_name)
-                    )
-                    if parts and parts[1]:
-                        where_if_cols.add(parts[1])
-                if kql_agg:
-                    has_aggregates = True
-                    summarize_columns.add(
-                        self._build_column_projection(kql_agg, column_alias)
-                    )
-                # No group by clause
-                # Do the columns have aliases ?
-                # Add additional and to handle case where : SELECT column_name as column_name
-                elif column_alias and column_alias != column_name:
-                    extend_columns.add(
-                        self._build_column_projection(column_name, column_alias, True)
-                    )
-                if column_alias:
-                    projection_columns.append(
-                        self._escape_and_quote_columns(column_alias, True)
-                    )
-                else:
-                    projection_columns.append(
-                        self._escape_and_quote_columns(column_name)
-                    )
             # group by columns
             by_columns = self._group_by(group_by_cols)
-            if has_aggregates or bool(
-                by_columns
-            ):  # Summarize can happen with or without aggregate being created
+            if has_aggregates or bool(by_columns):
                 summarize_statement = f"| summarize {', '.join(summarize_columns)} "
                 if by_columns:
-                    summarize_statement = (
-                        f"{summarize_statement} by {', '.join(by_columns)}"
-                    )
+                    summarize_statement = f"{summarize_statement} by {', '.join(by_columns)}"
             if extend_columns:
                 extend_statement = f"| extend {', '.join(sorted(extend_columns))}"
             project_statement = (
@@ -307,6 +253,67 @@ class KustoKqlCompiler(compiler.SQLCompiler):
             "sort": sort_statement,
             "predicate_if": " and ".join(where_if_cols) if where_if_cols else "",
         }
+
+    def _process_columns(self, columns) -> dict[str, any]:
+        """Process columns and return data structures for summarize, extend, and project."""
+        summarize_columns = set()
+        extend_columns = set()
+        projection_columns = []
+        has_aggregates = False
+        where_if_cols = set()
+
+        for column in [c for c in columns if c.name != "*"]:
+            column_name, column_alias = self._extract_column_name_and_alias(column)
+            column_alias = self._escape_and_quote_columns(column_alias, True)
+
+            kql_agg = self._extract_maybe_agg_column_parts(column_name)
+            is_conditional_aggregate = self._is_conditional_aggregate(column_name)
+
+            if is_conditional_aggregate:
+                has_aggregates = True
+                predicate = self._extract_predicate_from_conditional_agg(column_name, kql_agg)
+                if predicate:
+                    where_if_cols.add(predicate)
+
+            if kql_agg:
+                has_aggregates = True
+                summarize_columns.add(
+                    self._build_column_projection(kql_agg, column_alias)
+                )
+            elif column_alias and column_alias != column_name:
+                extend_columns.add(
+                    self._build_column_projection(column_name, column_alias, True)
+                )
+
+            projection_columns.append(
+                self._escape_and_quote_columns(column_alias, True)
+                if column_alias
+                else self._escape_and_quote_columns(column_name)
+            )
+
+        return {
+            "summarize_columns": summarize_columns,
+            "extend_columns": extend_columns,
+            "projection_columns": projection_columns,
+            "has_aggregates": has_aggregates,
+            "where_if_cols": where_if_cols,
+        }
+
+    def _is_conditional_aggregate(self, column_name: str) -> bool:
+        """Check if column_name contains a conditional aggregate function."""
+        for fn in conditional_aggregates:
+            if column_name.lower().__contains__(fn):
+                return True
+        return False
+
+    def _extract_predicate_from_conditional_agg(self, column_name: str, kql_agg: str | None) -> str | None:
+        """Extract predicate from conditional aggregate function."""
+        parts = (
+            self._extract_columns_and_predicate(kql_agg)
+            if kql_agg
+            else self._extract_columns_and_predicate(column_name)
+        )
+        return parts[1] if parts and parts[1] else None
 
     @staticmethod
     def _extract_maybe_agg_column_parts(column_name) -> str | None:
@@ -706,16 +713,14 @@ class KustoKqlCompiler(compiler.SQLCompiler):
         return return_value
 
     @staticmethod
-    def _extract_columns_and_predicate(call: str):
+    def _extract_columns_and_predicate(call: str) -> tuple[list[str], str | None]:
         """
         Given a function call string like:
           covariancepif(x, y, x % 3 == 0)
           countif(DamageCrops >0)
           sumif(a,DamageCrops >0)
-        Returns (columns: list[str], predicate: str|None)
+        Returns (columns: list[str], predicate: str|None).
         """
-        import re
-
         # Find the argument list
         m = re.match(r"(\w+)\s*\((.*)\)", call)
         if not m:

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -263,10 +263,18 @@ def test_percentile_by_text():
     assert query_compiled == query_expected
 
 
-def test_dcountif_by_text():
-    event_col = literal_column(
-        "dcountif(year, city == 'Paris' or city in ('Madrid'))"
-    ).label("Measure 1")
+@pytest.mark.parametrize(
+    ("f", "query_expected"),
+    [
+        pytest.param("dcountif(year, city == 'Paris' or city in ('Madrid'))", '["SalesData"]| where city == \'Paris\' or city in (\'Madrid\')| summarize ["Measure 1"] = dcountif(["year"], city == \'Paris\' or city in (\'Madrid\')) | project ["Measure 1"]'),
+        pytest.param("countif(id, type != 'FMCG')", '["SalesData"]| where type != \'FMCG\'| summarize ["Measure 1"] = countif(["id"], type != \'FMCG\') | project ["Measure 1"]'),
+        pytest.param("avgif(age, age >= 20)", '["SalesData"]| where age >= 20| summarize ["Measure 1"] = avgif(["age"], age >= 20) | project ["Measure 1"]'),
+        pytest.param("sumif(sales_amount, sales_amount < 1000 and (sales_history!='c' or is_new==true))", '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = sumif(["sales_amount"], sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]'),
+        pytest.param("covarianceif(sales_amount, tax, sales_amount < 1000 and (sales_history!='c' or is_new==true))", '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = covarianceif(["sales_amount"], ["tax"], sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]'),
+    ],
+)
+def test_agg_if_by(f,query_expected):
+    event_col = literal_column(f).label("Measure 1")
     query = select(
         [
             event_col,
@@ -275,12 +283,7 @@ def test_dcountif_by_text():
     query_compiled = str(
         query.compile(engine, compile_kwargs={"literal_binds": True})
     ).replace("\n", "")
-    # raw query text from query
-    query_expected = (
-        '["SalesData"]'
-        "| summarize [\"Measure 1\"] = dcountif([\"year\"], city == 'Paris' or city in ('Madrid')) "
-        '| project ["Measure 1"]'
-    )
+    # raw query text from query - predicate is now extracted to WHERE clause
     assert query_compiled == query_expected
 
 
@@ -296,9 +299,10 @@ def test_countif_by_text():
     query_compiled = str(
         query.compile(engine, compile_kwargs={"literal_binds": True})
     ).replace("\n", "")
-    # raw query text from query
+    # raw query text from query - predicate is now extracted to WHERE clause
     query_expected = (
         '["SalesData"]'
+        "| where city == 'Paris' OR city in ('Madrid')"
         "| summarize [\"Measure 1\"] = countif(city == 'Paris' OR city in ('Madrid')) "
         '| project ["Measure 1"]'
     )
@@ -541,7 +545,7 @@ def test_schema_from_metadata(
     ],
 )
 def test_match_aggregates(column_name: str, expected_aggregate: str):
-    kql_agg = KustoKqlCompiler._extract_maybe_agg_column_parts(column_name)
+    kql_agg, predicate = KustoKqlCompiler._extract_maybe_agg_column_parts(column_name)
     if expected_aggregate:
         assert kql_agg is not None
         assert kql_agg == expected_aggregate

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -267,18 +267,10 @@ def test_percentile_by_text():
     ("f", "query_expected"),
     [
         pytest.param(
-            "dcountif(year, city == 'Paris' or city in ('Madrid'))",
-            (
-                "[\"SalesData\"]| where city == 'Paris' or city in ('Madrid')| "
-                "summarize [\"Measure 1\"] = dcountif([\"year\"], city == 'Paris' or city in ('Madrid')) | "
-                'project ["Measure 1"]'
-            ),
-        ),
-        pytest.param(
-            "countif(id, type != 'FMCG')",
+            "countif(type != 'FMCG')",
             (
                 "[\"SalesData\"]| where type != 'FMCG'| "
-                'summarize ["Measure 1"] = countif(["id"], type != \'FMCG\') | '
+                "summarize [\"Measure 1\"] = countif(type != 'FMCG') | "
                 'project ["Measure 1"]'
             ),
         ),
@@ -299,6 +291,25 @@ def test_percentile_by_text():
                 'project ["Measure 1"]'
             ),
         ),
+        pytest.param(
+            (
+                """dcountif(["Channel"],iff(SID == 27, 'Partner',iff(SID == 28, 'Dealer',"""
+                """iff(SID == 1415 and Experience == 'mw', 'Online', iff(SID == 49, 'CrossSell',"""
+                """iff(SID == 50, 'Kiosk',iff(SID == 1415 and Experience == 'react-web-client', """
+                """'Misc', '')))))) in ('CrossSell','Dealer','Online','Partner','Kiosk','Misc'))"""
+            ),
+            (
+                """["SalesData"]| where iff(SID == 27, 'Partner',iff(SID == 28, 'Dealer',"""
+                """iff(SID == 1415 and Experience == 'mw', 'Online', iff(SID == 49, 'CrossSell',"""
+                """iff(SID == 50, 'Kiosk',iff(SID == 1415 and Experience == 'react-web-client', """
+                """'Misc', '')))))) in ('CrossSell','Dealer','Online','Partner','Kiosk','Misc')"""
+                """| summarize ["Measure 1"] = dcountif(["Channel"],iff(SID == 27, 'Partner',"""
+                """iff(SID == 28, 'Dealer',iff(SID == 1415 and Experience == 'mw', 'Online', """
+                """iff(SID == 49, 'CrossSell',iff(SID == 50, 'Kiosk',"""
+                """iff(SID == 1415 and Experience == 'react-web-client', 'Misc', '')))))) """
+                """in ('CrossSell','Dealer','Online','Partner','Kiosk','Misc')) | project ["Measure 1"]"""
+            ),
+        ),
         # TODO: enable once covarianceif is supported. This is multi arity and will need a fix in the code
     ],
 )
@@ -309,9 +320,11 @@ def test_agg_if_by(f, query_expected):
             event_col,
         ]
     ).select_from(text("SalesData"))
-    query_compiled = str(
-        query.compile(engine, compile_kwargs={"literal_binds": True})
-    ).replace("\n", "")
+    query_compiled = (
+        str(query.compile(engine, compile_kwargs={"literal_binds": True}))
+        .replace("\n", "")
+        .replace("\t", "")
+    )
     # raw query text from query - predicate is now extracted to WHERE clause
     assert query_compiled == query_expected
 

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -266,14 +266,30 @@ def test_percentile_by_text():
 @pytest.mark.parametrize(
     ("f", "query_expected"),
     [
-        pytest.param("dcountif(year, city == 'Paris' or city in ('Madrid'))", '["SalesData"]| where city == \'Paris\' or city in (\'Madrid\')| summarize ["Measure 1"] = dcountif(["year"], city == \'Paris\' or city in (\'Madrid\')) | project ["Measure 1"]'),
-        pytest.param("countif(id, type != 'FMCG')", '["SalesData"]| where type != \'FMCG\'| summarize ["Measure 1"] = countif(["id"], type != \'FMCG\') | project ["Measure 1"]'),
-        pytest.param("avgif(age, age >= 20)", '["SalesData"]| where age >= 20| summarize ["Measure 1"] = avgif(["age"], age >= 20) | project ["Measure 1"]'),
-        pytest.param("sumif(sales_amount, sales_amount < 1000 and (sales_history!='c' or is_new==true))", '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = sumif(["sales_amount"], sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]'),
-        pytest.param("covarianceif(sales_amount, tax, sales_amount < 1000 and (sales_history!='c' or is_new==true))", '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = covarianceif(["sales_amount"], ["tax"], sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]'),
+        pytest.param(
+            "dcountif(year, city == 'Paris' or city in ('Madrid'))",
+            "[\"SalesData\"]| where city == 'Paris' or city in ('Madrid')| summarize [\"Measure 1\"] = dcountif([\"year\"], city == 'Paris' or city in ('Madrid')) | project [\"Measure 1\"]",
+        ),
+        pytest.param(
+            "countif(id, type != 'FMCG')",
+            '["SalesData"]| where type != \'FMCG\'| summarize ["Measure 1"] = countif(["id"], type != \'FMCG\') | project ["Measure 1"]',
+        ),
+        pytest.param(
+            "avgif(age, age >= 20)",
+            '["SalesData"]| where age >= 20| summarize ["Measure 1"] = avgif(["age"], age >= 20) | project ["Measure 1"]',
+        ),
+        pytest.param(
+            "sumif(sales_amount, sales_amount < 1000 and (sales_history!='c' or is_new==true))",
+            '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = sumif(["sales_amount"], sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]',
+        ),
+        # TODO: enable once covarianceif is supported. This is multi arity and will need a fix in the code
+        # pytest.param(
+        #     "covarianceif(sales_amount, tax, sales_amount < 1000 and (sales_history!='c' or is_new==true))",
+        #     '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = covarianceif(sales_amount, tax, sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]',
+        # ),
     ],
 )
-def test_agg_if_by(f,query_expected):
+def test_agg_if_by(f, query_expected):
     event_col = literal_column(f).label("Measure 1")
     query = select(
         [
@@ -545,7 +561,7 @@ def test_schema_from_metadata(
     ],
 )
 def test_match_aggregates(column_name: str, expected_aggregate: str):
-    kql_agg, predicate = KustoKqlCompiler._extract_maybe_agg_column_parts(column_name)
+    kql_agg = KustoKqlCompiler._extract_maybe_agg_column_parts(column_name)
     if expected_aggregate:
         assert kql_agg is not None
         assert kql_agg == expected_aggregate

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -346,10 +346,12 @@ def test_agg_if_by(f, query_expected):
         pytest.param(
             [
                 literal_column("dcountif(id, type != 'FMCG')").label("Measure 1"),
-                literal_column("sumif(sales_amount, sales_amount < 1000)").label("Measure 2"),
+                literal_column("sumif(sales_amount, sales_amount < 1000)").label(
+                    "Measure 2"
+                ),
             ],
             (
-                '["SalesData"]| where sales_amount < 1000 or type != \'FMCG\''
+                "[\"SalesData\"]| where sales_amount < 1000 or type != 'FMCG'"
                 '| summarize ["Measure 1"] = dcountif(["id"], type != \'FMCG\'), '
                 '["Measure 2"] = sumif(["sales_amount"], sales_amount < 1000) '
                 '| project ["Measure 1"], ["Measure 2"]'

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -268,25 +268,38 @@ def test_percentile_by_text():
     [
         pytest.param(
             "dcountif(year, city == 'Paris' or city in ('Madrid'))",
-            "[\"SalesData\"]| where city == 'Paris' or city in ('Madrid')| summarize [\"Measure 1\"] = dcountif([\"year\"], city == 'Paris' or city in ('Madrid')) | project [\"Measure 1\"]",
+            (
+                "[\"SalesData\"]| where city == 'Paris' or city in ('Madrid')| "
+                "summarize [\"Measure 1\"] = dcountif([\"year\"], city == 'Paris' or city in ('Madrid')) | "
+                "project [\"Measure 1\"]"
+            ),
         ),
         pytest.param(
             "countif(id, type != 'FMCG')",
-            '["SalesData"]| where type != \'FMCG\'| summarize ["Measure 1"] = countif(["id"], type != \'FMCG\') | project ["Measure 1"]',
+            (
+                '["SalesData"]| where type != \'FMCG\'| '
+                'summarize ["Measure 1"] = countif(["id"], type != \'FMCG\') | '
+                'project ["Measure 1"]'
+            ),
         ),
         pytest.param(
             "avgif(age, age >= 20)",
-            '["SalesData"]| where age >= 20| summarize ["Measure 1"] = avgif(["age"], age >= 20) | project ["Measure 1"]',
+            (
+                '["SalesData"]| where age >= 20| '
+                'summarize ["Measure 1"] = avgif(["age"], age >= 20) | '
+                'project ["Measure 1"]'
+            ),
         ),
         pytest.param(
             "sumif(sales_amount, sales_amount < 1000 and (sales_history!='c' or is_new==true))",
-            '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = sumif(["sales_amount"], sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]',
+            (
+                '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| '
+                'summarize ["Measure 1"] = sumif(["sales_amount"], '
+                'sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | '
+                'project ["Measure 1"]'
+            ),
         ),
         # TODO: enable once covarianceif is supported. This is multi arity and will need a fix in the code
-        # pytest.param(
-        #     "covarianceif(sales_amount, tax, sales_amount < 1000 and (sales_history!='c' or is_new==true))",
-        #     '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| summarize ["Measure 1"] = covarianceif(sales_amount, tax, sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | project ["Measure 1"]',
-        # ),
     ],
 )
 def test_agg_if_by(f, query_expected):

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -329,6 +329,63 @@ def test_agg_if_by(f, query_expected):
     assert query_compiled == query_expected
 
 
+@pytest.mark.parametrize(
+    ("columns", "query_expected"),
+    [
+        pytest.param(
+            [
+                literal_column("avgif(age, age >= 20)").label("M1"),
+                literal_column("minif(prev, prev <= post)").label("M2"),
+            ],
+            (
+                '["SalesData"]| where age >= 20 or prev <= post'
+                '| summarize ["M1"] = avgif(["age"], age >= 20), ["M2"] = minif(["prev"], prev <= post) '
+                '| project ["M1"], ["M2"]'
+            ),
+        ),
+        pytest.param(
+            [
+                literal_column("dcountif(id, type != 'FMCG')").label("Measure 1"),
+                literal_column("sumif(sales_amount, sales_amount < 1000)").label("Measure 2"),
+            ],
+            (
+                '["SalesData"]| where sales_amount < 1000 or type != \'FMCG\''
+                '| summarize ["Measure 1"] = dcountif(["id"], type != \'FMCG\'), '
+                '["Measure 2"] = sumif(["sales_amount"], sales_amount < 1000) '
+                '| project ["Measure 1"], ["Measure 2"]'
+            ),
+        ),
+        pytest.param(
+            [
+                literal_column("countif(city == 'Paris' or city == 'Bordeaux' )").label(
+                    "FR Count"
+                ),
+                literal_column(
+                    "countif((city == 'Madrid' or city == 'Barcelona'))"
+                ).label("ES Count"),
+                literal_column("count(*)").label("Total Count"),
+            ],
+            (
+                """["SalesData"]| where (city == 'Madrid' or city == 'Barcelona') or """
+                """city == 'Paris' or city == 'Bordeaux'| summarize """
+                """["ES Count"] = countif((city == 'Madrid' or city == 'Barcelona')), """
+                """["FR Count"] = countif(city == 'Paris' or city == 'Bordeaux' ), """
+                """["Total Count"] = count() | project ["FR Count"], ["ES Count"], ["Total Count"]"""
+            ),
+        ),
+    ],
+)
+def test_multi_agg_if_by(columns, query_expected):
+    query = select(columns).select_from(text("SalesData"))
+    query_compiled = (
+        str(query.compile(engine, compile_kwargs={"literal_binds": True}))
+        .replace("\n", "")
+        .replace("\t", "")
+    )
+    # raw query text from query - predicate is now extracted to WHERE clause
+    assert query_compiled == query_expected
+
+
 def test_countif_by_text():
     event_col = literal_column("countif(city == 'Paris' OR city in ('Madrid'))").label(
         "Measure 1"

--- a/tests/unit/test_dialect_kql.py
+++ b/tests/unit/test_dialect_kql.py
@@ -271,13 +271,13 @@ def test_percentile_by_text():
             (
                 "[\"SalesData\"]| where city == 'Paris' or city in ('Madrid')| "
                 "summarize [\"Measure 1\"] = dcountif([\"year\"], city == 'Paris' or city in ('Madrid')) | "
-                "project [\"Measure 1\"]"
+                'project ["Measure 1"]'
             ),
         ),
         pytest.param(
             "countif(id, type != 'FMCG')",
             (
-                '["SalesData"]| where type != \'FMCG\'| '
+                "[\"SalesData\"]| where type != 'FMCG'| "
                 'summarize ["Measure 1"] = countif(["id"], type != \'FMCG\') | '
                 'project ["Measure 1"]'
             ),
@@ -293,9 +293,9 @@ def test_percentile_by_text():
         pytest.param(
             "sumif(sales_amount, sales_amount < 1000 and (sales_history!='c' or is_new==true))",
             (
-                '["SalesData"]| where sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)| '
+                "[\"SalesData\"]| where sales_amount < 1000 and (sales_history!='c' or is_new==true)| "
                 'summarize ["Measure 1"] = sumif(["sales_amount"], '
-                'sales_amount < 1000 and (sales_history!=\'c\' or is_new==true)) | '
+                "sales_amount < 1000 and (sales_history!='c' or is_new==true)) | "
                 'project ["Measure 1"]'
             ),
         ),


### PR DESCRIPTION
This pull request enhances the handling of conditional aggregate functions (like `sumif`, `countif`, etc.) in the Kusto SQLAlchemy dialect. The main improvement is the extraction of predicate conditions from these aggregates and moving them into the KQL `where` clause for more accurate and efficient query translation. The changes also introduce a utility function for parsing aggregate function arguments and expand test coverage for these scenarios.

