### PR TITLE
feat(61156998): date_trunc and T-SQL function translation for Superset (release 3.2.0)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -58,3 +58,15 @@ jobs:
 
       - name: Run unit tests
         run: make unit
+
+      # The emulator runs the real Kusto query engine locally, so the integration
+      # tests need no cluster and no credentials.
+      - name: Start the Kusto emulator
+        run: make emulator
+
+      - name: Run integration tests
+        run: make integration
+
+      - name: Stop the Kusto emulator
+        if: always()
+        run: make emulator-stop

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv install install-dev build clean check test unit integration release pypi
+.PHONY: venv install install-dev build clean check test unit integration emulator emulator-stop release pypi
 -include .env
 
 ##############################################################################
@@ -58,10 +58,27 @@ unit: # Run unit tests
 	$(PYTHON) -m pytest -v tests/unit/
 	@echo "Done.\n"
 
-integration: # Run integration tests
+integration: # Run integration tests (against the emulator unless KUSTO_URL is set)
 	@echo "Running integration tests..."
 	$(PYTHON) -m pytest -v tests/integration/
 	@echo "Done.\n"
+
+##############################################################################
+# Kusto emulator (local target for the integration tests)
+##############################################################################
+EMULATOR_IMAGE = mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest
+EMULATOR_NAME = kustainer
+
+emulator: # Start the Kusto emulator and wait until it answers
+	@echo "Starting the Kusto emulator..."
+	docker run -e ACCEPT_EULA=Y -m 4G -d -p 8080:8080 --name $(EMULATOR_NAME) $(EMULATOR_IMAGE)
+	@echo "Waiting for the query engine..."
+	@until curl -s -m 3 -o /dev/null -X POST -H 'Content-Type: application/json' \
+		-d '{"csl":".show cluster"}' http://localhost:8080/v1/rest/mgmt; do sleep 2; done
+	@echo "Ready on http://localhost:8080 (database NetDefaultDB).\n"
+
+emulator-stop: # Remove the emulator container
+	-docker rm -f $(EMULATOR_NAME)
 
 ##############################################################################
 # Build and cleanup

--- a/README.md
+++ b/README.md
@@ -105,6 +105,33 @@ kustokql+https://<CLUSTER_URL>/<DATABASE>?azure_ad_client_id=<CLIENT_ID>&azure_a
 > 
 > Current `master` branch of the `apache/superset` dependent on `sqlalchemy==1.4.36`. If you want to use `sqlalchemy-kusto` with the latest unstable version of `apache/superset`, you need to install version `2.*` of the package.
 
+## Running the tests
+
+Unit tests need nothing but the package itself:
+
+```shell
+make unit
+```
+
+Integration tests run against a local [Kusto emulator](https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview),
+so they need neither a cluster nor credentials:
+
+```shell
+make emulator      # starts the kustainer-linux container on http://localhost:8080
+make integration
+make emulator-stop
+```
+
+The emulator has no TLS and no authentication, hence the `kustosql+http://` URL:
+
+```
+kustosql+http://localhost:8080/NetDefaultDB
+```
+
+To run the same tests against a real cluster instead, set `KUSTO_URL`, `DATABASE` and
+the `AZURE_AD_*` variables (see `.env.sample`). When neither the emulator nor a cluster
+is reachable, the integration tests are skipped rather than failed.
+
 ## Contributing
 
 Please see the [CONTRIBUTING.md](.github/CONTRIBUTING.md) for development setup and contributing process guidelines.

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     entry_points={
         "sqlalchemy.dialects": [
             "kustosql.https = sqlalchemy_kusto.dialect_sql:KustoSqlHttpsDialect",
+            "kustosql.http = sqlalchemy_kusto.dialect_sql:KustoSqlHttpDialect",
             "kustokql.https = sqlalchemy_kusto.dialect_kql:KustoKqlHttpsDialect",
         ]
     },

--- a/sqlalchemy_kusto/dbapi.py
+++ b/sqlalchemy_kusto/dbapi.py
@@ -198,7 +198,10 @@ class Connection:
         self.cursors: list[Cursor] = []
         kcsb = None
 
-        if azure_ad_client_id and azure_ad_client_secret and azure_ad_tenant_id:
+        if cluster.startswith("http://"):
+            # Plain HTTP means the Kusto emulator: it has no TLS and no authentication.
+            kcsb = KustoConnectionStringBuilder(cluster)
+        elif azure_ad_client_id and azure_ad_client_secret and azure_ad_tenant_id:
             # Service Principal auth
             kcsb = KustoConnectionStringBuilder.with_aad_application_key_authentication(
                 connection_string=cluster,

--- a/sqlalchemy_kusto/dbapi.py
+++ b/sqlalchemy_kusto/dbapi.py
@@ -30,8 +30,6 @@ _GRAIN_TO_TSQL: dict[str, tuple[str, str]] = {
     "year": ("year", "0"),
 }
 
-_DATE_TRUNC_MARKER = "date_trunc("
-
 
 def _date_trunc_expr(grain: str, expr: str) -> str | None:
     """Build the T-SQL equivalent of date_trunc(grain, expr), or None if the grain is unknown.
@@ -66,15 +64,16 @@ def _skip_literal(sql: str, start: int) -> int:
     return len(sql)  # unterminated literal: treat the remainder as opaque
 
 
-def _split_date_trunc_args(sql: str, start: int) -> tuple[str, str, int] | None:
-    """Parse `grain, expr)` starting at `start`.
+def _split_call_args(sql: str, start: int) -> tuple[list[str], int] | None:
+    """Split the argument list of a call whose '(' ends just before `start`.
 
-    Returns (grain, expr, index just past the closing paren), or None when the call
-    is malformed, so the caller can leave such SQL for Kusto to reject.
+    Returns (arguments, index just past the closing paren), or None when the call is
+    unbalanced, so the caller can leave such SQL for Kusto to reject. Commas inside
+    nested calls and inside string literals do not split.
     """
+    args: list[str] = []
     depth = 1
-    comma = None
-    i = start
+    arg_start = i = start
     while i < len(sql):
         char = sql[i]
         if char in "'\"":
@@ -85,20 +84,57 @@ def _split_date_trunc_args(sql: str, start: int) -> tuple[str, str, int] | None:
         elif char == ")":
             depth -= 1
             if depth == 0:
-                return (sql[start:comma], sql[comma + 1 : i], i + 1) if comma else None
-        elif char == "," and depth == 1 and comma is None:
-            comma = i
+                args.append(sql[arg_start:i])
+                return args, i + 1
+        elif char == "," and depth == 1:
+            args.append(sql[arg_start:i])
+            arg_start = i + 1
         i += 1
     return None
 
 
-def _translate_raw_date_trunc(sql: str) -> str:
-    """Rewrite date_trunc('grain', expr) in a raw SQL string as T-SQL DATEADD/DATEDIFF.
+def _date_part_expr(unit: str, expr: str) -> str | None:
+    """date_part('unit', x) → DATEPART(unit, x); T-SQL spells the unit bare."""
+    part = unit.strip().strip("'\"").lower()
+    if not part.isalpha():
+        return None
+    return f"DATEPART({part}, {expr})"
 
-    Applied in Cursor.execute() so it covers every execution path including Superset SQLLab,
-    which calls the DBAPI cursor directly via engine.raw_connection(), bypassing dialect hooks.
-    Function and grain names match case-insensitively; string literals and unknown grains
-    are left untouched.
+
+# Functions Kusto's T-SQL emulation does not implement, mapped to the form it does.
+# Every replacement here was executed against the Kusto emulator; anything without an
+# exact equivalent (FORMAT, DATE_FORMAT, TRY_CAST, JSON_VALUE, OPENJSON) is left alone
+# on purpose, so Kusto reports it instead of us guessing at the semantics.
+_CALL_TRANSLATIONS: dict[str, tuple[int, Any]] = {
+    # name: (argument count, builder)
+    "date_trunc": (2, _date_trunc_expr),
+    "datetrunc": (2, _date_trunc_expr),  # T-SQL 2022 spelling, same arguments
+    "date_part": (2, _date_part_expr),
+    "startofday": (1, lambda expr: _date_trunc_expr("day", expr)),
+    "startofweek": (1, lambda expr: _date_trunc_expr("week_sun", expr)),
+    "startofmonth": (1, lambda expr: _date_trunc_expr("month", expr)),
+    "startofyear": (1, lambda expr: _date_trunc_expr("year", expr)),
+    "ifnull": (2, lambda a, b: f"COALESCE({a}, {b})"),
+    # Kusto has a single datetime type, so CAST/CONVERT to DATE keeps the time of day.
+    # DATE(x) and to_date(x) are expected to drop it, which is a truncation to the day.
+    "to_date": (1, lambda expr: _date_trunc_expr("day", expr)),
+    "date": (1, lambda expr: _date_trunc_expr("day", expr)),
+}
+
+# Longest first, so "date" cannot shadow "date_trunc".
+_TRANSLATION_NAMES_LONGEST_FIRST = sorted(_CALL_TRANSLATIONS, key=len, reverse=True)
+# First letters of those names: lets the scanner skip most characters outright.
+_TRANSLATION_FIRST_CHARS = frozenset(name[0] for name in _CALL_TRANSLATIONS)
+_IDENTIFIER_CHARS = frozenset('_.[]"')
+
+
+def _translate_raw_functions(sql: str) -> str:
+    """Rewrite calls Kusto cannot parse into their T-SQL equivalents.
+
+    Applied in Cursor.execute() so it covers every execution path including Superset
+    SQLLab, which talks to the DBAPI cursor directly and bypasses the dialect hooks.
+    Names match case-insensitively; string literals, unknown grains and unknown call
+    shapes are left untouched.
     """
     result: list[str] = []
     sql_lower = sql.lower()
@@ -111,22 +147,81 @@ def _translate_raw_date_trunc(sql: str) -> str:
             i = end
             continue
 
-        if not sql_lower.startswith(_DATE_TRUNC_MARKER, i):
+        match = _match_call_name(sql, sql_lower, i)
+        if match is None:
             result.append(sql[i])
             i += 1
             continue
 
-        parsed = _split_date_trunc_args(sql, i + len(_DATE_TRUNC_MARKER))
-        if parsed is None:
+        name, args_start = match
+        arity, builder = _CALL_TRANSLATIONS[name]
+        parsed = _split_call_args(sql, args_start)
+        if parsed is None:  # unbalanced parentheses: leave the remainder as it is
             result.append(sql[i:])
             break
 
-        grain, expr, end = parsed
-        translated = _date_trunc_expr(grain, _translate_raw_date_trunc(expr.strip()))
+        args, end = parsed
+        if len(args) != arity or any(not arg.strip() for arg in args):
+            result.append(sql[i:end])
+            i = end
+            continue
+
+        translated = builder(*(_translate_raw_functions(arg.strip()) for arg in args))
         result.append(translated if translated is not None else sql[i:end])
         i = end
 
     return "".join(result)
+
+
+def _match_call_name(sql: str, sql_lower: str, i: int) -> tuple[str, int] | None:
+    """Return (function name, index just past its '(') if a known call starts at `i`."""
+    if sql_lower[i] not in _TRANSLATION_FIRST_CHARS:
+        return None  # cheap gate: no translated name starts with this character
+    previous = sql[i - 1] if i else ""
+    if previous.isalnum() or previous in _IDENTIFIER_CHARS:
+        return None  # part of a longer identifier, e.g. my_date(
+    for name in _TRANSLATION_NAMES_LONGEST_FIRST:
+        if not sql_lower.startswith(name, i):
+            continue
+        after = i + len(name)
+        while after < len(sql) and sql[after] in " \t\r\n":
+            after += 1  # `date (x)` is the same call as `date(x)`
+        if sql[after : after + 1] == "(":
+            return name, after + 1
+    return None
+
+
+def is_tsql_query(operation: str) -> bool:
+    """Whether to send `operation` as T-SQL rather than KQL.
+
+    Kusto needs the query language up front and the only hint available is the text.
+    A leading WITH counts: Kusto executes CTEs, and treating those as KQL used to make
+    every CTE query fail before it was even sent. Leading whitespace, semicolons and
+    comments are skipped; scanning them by hand keeps this linear, which a regex with
+    a repeated alternation would not be.
+    """
+    i, length = 0, len(operation)
+    while i < length:
+        char = operation[i]
+        if char.isspace() or char == ";":
+            i += 1
+        elif operation.startswith("--", i):
+            end = operation.find("\n", i)
+            i = length if end == -1 else end + 1
+        elif operation.startswith("/*", i):
+            end = operation.find("*/", i)
+            i = length if end == -1 else end + 2
+        else:
+            break
+    for keyword in ("select", "with"):
+        end = i + len(keyword)
+        if operation[i:end].lower() != keyword:
+            continue
+        # must be a whole word: `withdrawals | count` is a KQL table, not a CTE
+        following = operation[end : end + 1]
+        if not (following.isalnum() or following == "_"):
+            return True
+    return False
 
 
 def check_closed(func):
@@ -317,10 +412,10 @@ class Cursor:
     @check_closed
     def execute(self, operation, parameters=None) -> "Cursor":
         """Executes query. Supports only SELECT statements."""
-        if operation.lower().startswith("select"):
+        if is_tsql_query(operation):
             self.properties.set_option("query_language", "sql")
             # T-SQL only: a KQL query must never be rewritten.
-            operation = _translate_raw_date_trunc(operation)
+            operation = _translate_raw_functions(operation)
         else:
             self.properties.set_option("query_language", "kql")
 

--- a/sqlalchemy_kusto/dbapi.py
+++ b/sqlalchemy_kusto/dbapi.py
@@ -12,117 +12,119 @@ from azure.kusto.data.exceptions import KustoAuthenticationError, KustoServiceEr
 
 from sqlalchemy_kusto import errors
 
-# PostgreSQL date_trunc grain → T-SQL datepart name
-_GRAIN_TO_TSQL: dict[str, str] = {
-    "microseconds": "millisecond",  # T-SQL has no microsecond
-    "milliseconds": "millisecond",
-    "second": "second",
-    "minute": "minute",
-    "hour": "hour",
-    "day": "day",
-    "week": "week",
-    "week_sun": "week",  # extension: Sunday-based week (not in PostgreSQL)
-    "month": "month",
-    "quarter": "quarter",
-    "year": "year",
+# PostgreSQL date_trunc grain → (T-SQL datepart, DATEDIFF base epoch).
+# Epoch 0 is 1900-01-01, a Monday. Sub-day grains use '2000-01-01' instead because
+# DATEDIFF(second, 0, <today>) overflows a 32-bit int.
+# week_sun uses epoch -1 = 1899-12-31, a Sunday, keeping weeks Sunday-aligned.
+# Grains finer than a second are deliberately absent: DATEDIFF(millisecond, ...)
+# overflows after 24 days from any fixed epoch, so there is no usable form.
+_GRAIN_TO_TSQL: dict[str, tuple[str, str]] = {
+    "second": ("second", "'2000-01-01'"),
+    "minute": ("minute", "'2000-01-01'"),
+    "hour": ("hour", "'2000-01-01'"),
+    "day": ("day", "0"),
+    "week": ("week", "0"),
+    "week_sun": ("week", "-1"),  # extension: Sunday-based week (not in PostgreSQL)
+    "month": ("month", "0"),
+    "quarter": ("quarter", "0"),
+    "year": ("year", "0"),
 }
 
-# Safe DATEDIFF base epoch per grain.
-# For sub-day grains, epoch 0 (1900-01-01) causes integer overflow; use 2000-01-01.
-# week_sun uses epoch -1 = 1899-12-31 (Sunday), so DATEADD/DATEDIFF stay in Sunday-aligned weeks.
-_GRAIN_EPOCH: dict[str, str] = {
-    "microseconds": "'2000-01-01'",
-    "milliseconds": "'2000-01-01'",
-    "second": "'2000-01-01'",
-    "minute": "'2000-01-01'",
-    "hour": "'2000-01-01'",
-    "day": "0",
-    "week": "0",
-    "week_sun": "-1",
-    "month": "0",
-    "quarter": "0",
-    "year": "0",
-}
+_DATE_TRUNC_MARKER = "date_trunc("
+
+
+def _date_trunc_expr(grain: str, expr: str) -> str | None:
+    """Build the T-SQL equivalent of date_trunc(grain, expr), or None if the grain is unknown.
+
+    Grain matching is case-insensitive and tolerates surrounding quotes.
+    """
+    key = grain.strip().strip("'\"").lower()
+    part_and_epoch = _GRAIN_TO_TSQL.get(key)
+    if part_and_epoch is None:
+        return None
+
+    part, epoch = part_and_epoch
+    if key == "week":
+        # DATEDIFF(week, ...) counts Sunday boundaries while epoch 0 is a Monday.
+        # Shifting the input back one day keeps Sunday inside the preceding Mon-Sun
+        # week, which is PostgreSQL's ISO (Monday-based) truncation.
+        expr = f"DATEADD(day, -1, {expr})"
+    return f"DATEADD({part}, DATEDIFF({part}, {epoch}, {expr}), {epoch})"
+
+
+def _skip_literal(sql: str, start: int) -> int:
+    """Return the index just past the string literal opening at `start`."""
+    quote = sql[start]
+    i = start + 1
+    while i < len(sql):
+        if sql[i] == quote:
+            if sql[i + 1 : i + 2] == quote:  # doubled quote escapes itself
+                i += 2
+                continue
+            return i + 1
+        i += 1
+    return len(sql)  # unterminated literal: treat the remainder as opaque
+
+
+def _split_date_trunc_args(sql: str, start: int) -> tuple[str, str, int] | None:
+    """Parse `grain, expr)` starting at `start`.
+
+    Returns (grain, expr, index just past the closing paren), or None when the call
+    is malformed, so the caller can leave such SQL for Kusto to reject.
+    """
+    depth = 1
+    comma = None
+    i = start
+    while i < len(sql):
+        char = sql[i]
+        if char in "'\"":
+            i = _skip_literal(sql, i)
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return (sql[start:comma], sql[comma + 1 : i], i + 1) if comma else None
+        elif char == "," and depth == 1 and comma is None:
+            comma = i
+        i += 1
+    return None
 
 
 def _translate_raw_date_trunc(sql: str) -> str:
-    """Translate date_trunc('grain', expr) calls in a raw SQL string to T-SQL DATEADD/DATEDIFF.
+    """Rewrite date_trunc('grain', expr) in a raw SQL string as T-SQL DATEADD/DATEDIFF.
 
     Applied in Cursor.execute() so it covers every execution path including Superset SQLLab,
     which calls the DBAPI cursor directly via engine.raw_connection(), bypassing dialect hooks.
-    Grain and function name matching are case-insensitive. Unknown grains are left unchanged.
+    Function and grain names match case-insensitively; string literals and unknown grains
+    are left untouched.
     """
-    marker = "date_trunc("
     result: list[str] = []
-    i = 0
     sql_lower = sql.lower()
+    i = 0
 
     while i < len(sql):
-        pos = sql_lower.find(marker, i)
-        if pos == -1:
+        if sql[i] in "'\"":  # never rewrite anything inside a string literal
+            end = _skip_literal(sql, i)
+            result.append(sql[i:end])
+            i = end
+            continue
+
+        if not sql_lower.startswith(_DATE_TRUNC_MARKER, i):
+            result.append(sql[i])
+            i += 1
+            continue
+
+        parsed = _split_date_trunc_args(sql, i + len(_DATE_TRUNC_MARKER))
+        if parsed is None:
             result.append(sql[i:])
             break
 
-        result.append(sql[i:pos])
-
-        # Walk forward tracking depth to find the matching ')'.
-        depth = 1
-        j = pos + len(marker)
-        while j < len(sql) and depth > 0:
-            if sql[j] == "(":
-                depth += 1
-            elif sql[j] == ")":
-                depth -= 1
-            j += 1
-
-        if depth != 0:
-            # Unbalanced parentheses — leave the rest unchanged.
-            result.append(sql[pos:])
-            i = len(sql)
-            break
-
-        interior = sql[pos + len(marker) : j - 1]
-
-        # Split interior at the first top-level comma to get grain and expression.
-        comma_pos: int | None = None
-        inner_depth = 0
-        for k, ch in enumerate(interior):
-            if ch == "(":
-                inner_depth += 1
-            elif ch == ")":
-                inner_depth -= 1
-            elif ch == "," and inner_depth == 0:
-                comma_pos = k
-                break
-
-        if comma_pos is None:
-            # Malformed call — leave unchanged.
-            result.append(sql[pos:j])
-            i = j
-            continue
-
-        grain_raw = interior[:comma_pos].strip().strip("'\"")
-        grain = grain_raw.lower()
-        expr = interior[comma_pos + 1 :].strip()
-
-        part = _GRAIN_TO_TSQL.get(grain)
-        if part is None:
-            # Unknown grain — leave the whole call unchanged.
-            result.append(sql[pos:j])
-            i = j
-            continue
-
-        epoch = _GRAIN_EPOCH.get(grain, "0")
-        if grain == "week":
-            # T-SQL DATEDIFF(week,...) counts Sunday boundaries, but epoch 0 is Monday.
-            # Shift the input back 1 day so Sunday stays inside its Mon-Sat week,
-            # producing ISO-standard Monday-based truncation (matches PostgreSQL semantics).
-            result.append(
-                f"DATEADD({part}, DATEDIFF({part}, {epoch}, DATEADD(day, -1, {expr})), {epoch})"
-            )
-        else:
-            result.append(f"DATEADD({part}, DATEDIFF({part}, {epoch}, {expr}), {epoch})")
-        i = j
+        grain, expr, end = parsed
+        translated = _date_trunc_expr(grain, _translate_raw_date_trunc(expr.strip()))
+        result.append(translated if translated is not None else sql[i:end])
+        i = end
 
     return "".join(result)
 
@@ -314,10 +316,12 @@ class Cursor:
         """Executes query. Supports only SELECT statements."""
         if operation.lower().startswith("select"):
             self.properties.set_option("query_language", "sql")
+            # T-SQL only: a KQL query must never be rewritten.
+            operation = _translate_raw_date_trunc(operation)
         else:
             self.properties.set_option("query_language", "kql")
 
-        query = Cursor._apply_parameters(_translate_raw_date_trunc(operation), parameters)
+        query = Cursor._apply_parameters(operation, parameters)
         query = query.rstrip()
         try:
             server_response = self.kusto_client.execute(

--- a/sqlalchemy_kusto/dbapi.py
+++ b/sqlalchemy_kusto/dbapi.py
@@ -12,6 +12,120 @@ from azure.kusto.data.exceptions import KustoAuthenticationError, KustoServiceEr
 
 from sqlalchemy_kusto import errors
 
+# PostgreSQL date_trunc grain → T-SQL datepart name
+_GRAIN_TO_TSQL: dict[str, str] = {
+    "microseconds": "millisecond",  # T-SQL has no microsecond
+    "milliseconds": "millisecond",
+    "second": "second",
+    "minute": "minute",
+    "hour": "hour",
+    "day": "day",
+    "week": "week",
+    "week_sun": "week",  # extension: Sunday-based week (not in PostgreSQL)
+    "month": "month",
+    "quarter": "quarter",
+    "year": "year",
+}
+
+# Safe DATEDIFF base epoch per grain.
+# For sub-day grains, epoch 0 (1900-01-01) causes integer overflow; use 2000-01-01.
+# week_sun uses epoch -1 = 1899-12-31 (Sunday), so DATEADD/DATEDIFF stay in Sunday-aligned weeks.
+_GRAIN_EPOCH: dict[str, str] = {
+    "microseconds": "'2000-01-01'",
+    "milliseconds": "'2000-01-01'",
+    "second": "'2000-01-01'",
+    "minute": "'2000-01-01'",
+    "hour": "'2000-01-01'",
+    "day": "0",
+    "week": "0",
+    "week_sun": "-1",
+    "month": "0",
+    "quarter": "0",
+    "year": "0",
+}
+
+
+def _translate_raw_date_trunc(sql: str) -> str:
+    """Translate date_trunc('grain', expr) calls in a raw SQL string to T-SQL DATEADD/DATEDIFF.
+
+    Applied in Cursor.execute() so it covers every execution path including Superset SQLLab,
+    which calls the DBAPI cursor directly via engine.raw_connection(), bypassing dialect hooks.
+    Grain and function name matching are case-insensitive. Unknown grains are left unchanged.
+    """
+    marker = "date_trunc("
+    result: list[str] = []
+    i = 0
+    sql_lower = sql.lower()
+
+    while i < len(sql):
+        pos = sql_lower.find(marker, i)
+        if pos == -1:
+            result.append(sql[i:])
+            break
+
+        result.append(sql[i:pos])
+
+        # Walk forward tracking depth to find the matching ')'.
+        depth = 1
+        j = pos + len(marker)
+        while j < len(sql) and depth > 0:
+            if sql[j] == "(":
+                depth += 1
+            elif sql[j] == ")":
+                depth -= 1
+            j += 1
+
+        if depth != 0:
+            # Unbalanced parentheses — leave the rest unchanged.
+            result.append(sql[pos:])
+            i = len(sql)
+            break
+
+        interior = sql[pos + len(marker) : j - 1]
+
+        # Split interior at the first top-level comma to get grain and expression.
+        comma_pos: int | None = None
+        inner_depth = 0
+        for k, ch in enumerate(interior):
+            if ch == "(":
+                inner_depth += 1
+            elif ch == ")":
+                inner_depth -= 1
+            elif ch == "," and inner_depth == 0:
+                comma_pos = k
+                break
+
+        if comma_pos is None:
+            # Malformed call — leave unchanged.
+            result.append(sql[pos:j])
+            i = j
+            continue
+
+        grain_raw = interior[:comma_pos].strip().strip("'\"")
+        grain = grain_raw.lower()
+        expr = interior[comma_pos + 1 :].strip()
+
+        part = _GRAIN_TO_TSQL.get(grain)
+        if part is None:
+            # Unknown grain — leave the whole call unchanged.
+            result.append(sql[pos:j])
+            i = j
+            continue
+
+        epoch = _GRAIN_EPOCH.get(grain, "0")
+        if grain == "week":
+            # T-SQL DATEDIFF(week,...) counts Sunday boundaries, but epoch 0 is Monday.
+            # Shift the input back 1 day so Sunday stays inside its Mon-Sat week,
+            # producing ISO-standard Monday-based truncation (matches PostgreSQL semantics).
+            result.append(
+                f"DATEADD({part}, DATEDIFF({part}, {epoch}, DATEADD(day, -1, {expr})), {epoch})"
+            )
+        else:
+            result.append(f"DATEADD({part}, DATEDIFF({part}, {epoch}, {expr}), {epoch})")
+        i = j
+
+    return "".join(result)
+
 
 def check_closed(func):
     """Decorator that checks if connection/cursor is closed."""
@@ -203,7 +317,7 @@ class Cursor:
         else:
             self.properties.set_option("query_language", "kql")
 
-        query = Cursor._apply_parameters(operation, parameters)
+        query = Cursor._apply_parameters(_translate_raw_date_trunc(operation), parameters)
         query = query.rstrip()
         try:
             server_response = self.kusto_client.execute(

--- a/sqlalchemy_kusto/dbapi.py
+++ b/sqlalchemy_kusto/dbapi.py
@@ -113,6 +113,20 @@ def _split_call_args(sql: str, start: int) -> tuple[list[str], int] | None:
     return None
 
 
+def _fold_lower_literal(arg: str) -> str | None:
+    """lower('LITERAL') → 'literal'; anything but a single string literal stays put.
+
+    Kusto requires a LIKE pattern to be a string literal and rejects lower('%x%')
+    with "OTR0001: LIKE pattern is not a string" — yet SQLAlchemy's stock ILIKE
+    compiles to exactly lower(x) LIKE lower(y). Folding the constant keeps the
+    pattern a literal without losing the case-insensitive match; lower() on the
+    left-hand column is valid Kusto and passes through untouched.
+    """
+    if arg.startswith("'") and _skip_literal(arg, 0) == len(arg):
+        return arg.lower()
+    return None
+
+
 def _date_part_expr(unit: str, expr: str) -> str | None:
     """date_part('unit', x) → DATEPART(unit, x); T-SQL spells the unit bare."""
     part = unit.strip().strip("'\"").lower()
@@ -139,6 +153,7 @@ _CALL_TRANSLATIONS: dict[str, tuple[int, Any]] = {
     # DATE(x) and to_date(x) are expected to drop it, which is a truncation to the day.
     "to_date": (1, lambda expr: _date_trunc_expr("day", expr)),
     "date": (1, lambda expr: _date_trunc_expr("day", expr)),
+    "lower": (1, _fold_lower_literal),
 }
 
 # Longest first, so "date" cannot shadow "date_trunc".
@@ -432,15 +447,16 @@ class Cursor:
     @check_closed
     def execute(self, operation, parameters=None) -> "Cursor":
         """Executes query. Supports only SELECT statements."""
-        if is_tsql_query(operation):
-            self.properties.set_option("query_language", "sql")
-            # T-SQL only: a KQL query must never be rewritten.
-            operation = _translate_raw_functions(operation)
-        else:
-            self.properties.set_option("query_language", "kql")
+        tsql = is_tsql_query(operation)
+        self.properties.set_option("query_language", "sql" if tsql else "kql")
 
         query = Cursor._apply_parameters(operation, parameters)
         query = query.rstrip()
+        if tsql:
+            # After parameter substitution, so a bound ILIKE pattern inside
+            # lower(%(p)s) can fold into the string literal Kusto requires.
+            # T-SQL only: a KQL query must never be rewritten.
+            query = _translate_raw_functions(query)
         try:
             server_response = self.kusto_client.execute(
                 self.database, query, self.properties

--- a/sqlalchemy_kusto/dbapi.py
+++ b/sqlalchemy_kusto/dbapi.py
@@ -64,6 +64,25 @@ def _skip_literal(sql: str, start: int) -> int:
     return len(sql)  # unterminated literal: treat the remainder as opaque
 
 
+def _skip_opaque(sql: str, i: int) -> int | None:
+    """Index just past the literal or comment starting at `i`, else None.
+
+    Comments must be skipped, not just left in place: an apostrophe inside one
+    ("-- don't ask") would otherwise be read as the start of a string literal and
+    swallow the rest of the query, so a real call after it never got translated.
+    """
+    char = sql[i]
+    if char in "'\"":
+        return _skip_literal(sql, i)
+    if sql.startswith("--", i):
+        end = sql.find("\n", i)
+        return len(sql) if end == -1 else end + 1
+    if sql.startswith("/*", i):
+        end = sql.find("*/", i)
+        return len(sql) if end == -1 else end + 2
+    return None
+
+
 def _split_call_args(sql: str, start: int) -> tuple[list[str], int] | None:
     """Split the argument list of a call whose '(' ends just before `start`.
 
@@ -76,8 +95,9 @@ def _split_call_args(sql: str, start: int) -> tuple[list[str], int] | None:
     arg_start = i = start
     while i < len(sql):
         char = sql[i]
-        if char in "'\"":
-            i = _skip_literal(sql, i)
+        skipped = _skip_opaque(sql, i)
+        if skipped is not None:
+            i = skipped
             continue
         if char == "(":
             depth += 1
@@ -141,8 +161,8 @@ def _translate_raw_functions(sql: str) -> str:
     i = 0
 
     while i < len(sql):
-        if sql[i] in "'\"":  # never rewrite anything inside a string literal
-            end = _skip_literal(sql, i)
+        end = _skip_opaque(sql, i)  # never rewrite inside a literal or a comment
+        if end is not None:
             result.append(sql[i:end])
             i = end
             continue

--- a/sqlalchemy_kusto/dialect_base.py
+++ b/sqlalchemy_kusto/dialect_base.py
@@ -78,8 +78,12 @@ class KustoBaseDialect(default.DefaultDialect, ABC):
         return sqlalchemy_kusto
 
     def create_connect_args(self, url: URL) -> tuple[list[Any], dict[str, Any]]:
+        # The driver part of the URL carries the scheme: kustosql+https:// for a real
+        # cluster, kustosql+http:// for the Kusto emulator (plain HTTP, custom port).
+        scheme = url.get_driver_name() or "https"
+        host = url.host if url.port is None else f"{url.host}:{url.port}"
         kwargs: dict[str, Any] = {
-            "cluster": "https://" + url.host,
+            "cluster": f"{scheme}://{host}",
             "database": url.database,
         }
 

--- a/sqlalchemy_kusto/dialect_sql.py
+++ b/sqlalchemy_kusto/dialect_sql.py
@@ -1,16 +1,165 @@
+from sqlalchemy import types
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import compiler
+from sqlalchemy.sql.functions import GenericFunction
 
 from sqlalchemy_kusto.dialect_base import KustoBaseDialect
+
+# PostgreSQL date_trunc grain → T-SQL datepart name
+_GRAIN_TO_TSQL: dict[str, str] = {
+    "microseconds": "millisecond",  # T-SQL has no microsecond
+    "milliseconds": "millisecond",
+    "second": "second",
+    "minute": "minute",
+    "hour": "hour",
+    "day": "day",
+    "week": "week",
+    "week_sun": "week",  # extension: Sunday-based week (not in PostgreSQL)
+    "month": "month",
+    "quarter": "quarter",
+    "year": "year",
+}
+
+# Safe DATEDIFF base epoch per grain.
+# For sub-day grains, epoch 0 (1900-01-01) causes integer overflow; use 2000-01-01.
+# week_sun uses epoch -1 = 1899-12-31 (Sunday), so DATEADD/DATEDIFF stay in Sunday-aligned weeks.
+_GRAIN_EPOCH: dict[str, str] = {
+    "microseconds": "'2000-01-01'",
+    "milliseconds": "'2000-01-01'",
+    "second": "'2000-01-01'",
+    "minute": "'2000-01-01'",
+    "hour": "'2000-01-01'",
+    "day": "0",
+    "week": "0",
+    "week_sun": "-1",
+    "month": "0",
+    "quarter": "0",
+    "year": "0",
+}
+
+
+def _translate_raw_date_trunc(sql: str) -> str:
+    """Translate date_trunc('grain', expr) calls in a raw SQL string to T-SQL DATEADD/DATEDIFF.
+
+    Only the kustosql dialect calls this.  The kql dialect has its own compiler path.
+    Grain matching is case-insensitive.  Unknown grains are left unchanged.
+    """
+    marker = "date_trunc("
+    result: list[str] = []
+    i = 0
+    sql_lower = sql.lower()
+
+    while i < len(sql):
+        pos = sql_lower.find(marker, i)
+        if pos == -1:
+            result.append(sql[i:])
+            break
+
+        result.append(sql[i:pos])
+
+        # Walk forward tracking depth to find the matching ')'.
+        depth = 1
+        j = pos + len(marker)
+        while j < len(sql) and depth > 0:
+            if sql[j] == "(":
+                depth += 1
+            elif sql[j] == ")":
+                depth -= 1
+            j += 1
+
+        if depth != 0:
+            # Unbalanced parentheses — leave the rest unchanged.
+            result.append(sql[pos:])
+            i = len(sql)
+            break
+
+        interior = sql[pos + len(marker) : j - 1]
+
+        # Split interior at the first top-level comma to get grain and expression.
+        comma_pos: int | None = None
+        inner_depth = 0
+        for k, ch in enumerate(interior):
+            if ch == "(":
+                inner_depth += 1
+            elif ch == ")":
+                inner_depth -= 1
+            elif ch == "," and inner_depth == 0:
+                comma_pos = k
+                break
+
+        if comma_pos is None:
+            # Malformed call — leave unchanged.
+            result.append(sql[pos:j])
+            i = j
+            continue
+
+        grain_raw = interior[:comma_pos].strip().strip("'\"")
+        grain = grain_raw.lower()
+        expr = interior[comma_pos + 1 :].strip()
+
+        part = _GRAIN_TO_TSQL.get(grain)
+        if part is None:
+            # Unknown grain — leave the whole call unchanged.
+            result.append(sql[pos:j])
+            i = j
+            continue
+
+        epoch = _GRAIN_EPOCH.get(grain, "0")
+        if grain == "week":
+            # T-SQL DATEDIFF(week,...) counts Sunday boundaries, but epoch 0 is Monday.
+            # Shift the input back 1 day so Sunday stays inside its Mon-Sat week,
+            # producing ISO-standard Monday-based truncation (matches PostgreSQL semantics).
+            result.append(
+                f"DATEADD({part}, DATEDIFF({part}, {epoch}, DATEADD(day, -1, {expr})), {epoch})"
+            )
+        else:
+            result.append(f"DATEADD({part}, DATEDIFF({part}, {epoch}, {expr}), {epoch})")
+        i = j
+
+    return "".join(result)
+
+
+class date_trunc(GenericFunction):  # noqa: N801
+    """PostgreSQL-style date_trunc compiled to T-SQL DATEADD/DATEDIFF for Kusto."""
+
+    name = "date_trunc"
+    type = types.DateTime()
+    inherit_cache = True
+
+
+@compiles(date_trunc, "kustosql")
+def _compile_date_trunc(element, compiler, **kw):
+    grain_clause, col_clause = list(element.clauses)
+
+    if hasattr(grain_clause, "value"):
+        grain = str(grain_clause.value).strip("'\" ").lower()
+    else:
+        grain = compiler.process(grain_clause, literal_binds=True, **kw).strip("'\" ").lower()
+
+    t_sql_part = _GRAIN_TO_TSQL.get(grain, grain)
+    epoch = _GRAIN_EPOCH.get(grain, "0")
+    col = compiler.process(col_clause, **kw)
+
+    if grain == "week":
+        # T-SQL DATEDIFF(week,...) counts Sunday boundaries, but epoch 0 is Monday.
+        # Shift the input back 1 day so Sunday stays inside its Mon-Sat week,
+        # producing ISO-standard Monday-based truncation (matches PostgreSQL semantics).
+        return f"DATEADD({t_sql_part}, DATEDIFF({t_sql_part}, {epoch}, DATEADD(day, -1, {col})), {epoch})"
+
+    return f"DATEADD({t_sql_part}, DATEDIFF({t_sql_part}, {epoch}, {col}), {epoch})"
 
 
 class KustoSqlCompiler(compiler.SQLCompiler):
     def get_select_precolumns(self, select, **kw) -> str:
-        """Kusto uses TOP instead of LIMIT."""
+        """Kusto uses TOP instead of LIMIT; also requires TOP when ORDER BY has no LIMIT."""
         select_precolumns = super().get_select_precolumns(select, **kw)
 
         if select._limit_clause is not None:
             kw["literal_execute"] = True
             select_precolumns += f"TOP {self.process(select._limit_clause, **kw)} "
+        elif select._order_by_clauses:
+            # Kusto T-SQL requires a TOP clause when ORDER BY is present without LIMIT
+            select_precolumns += f"TOP {self.dialect.max_top_n} "
 
         return select_precolumns
 
@@ -24,14 +173,10 @@ class KustoSqlCompiler(compiler.SQLCompiler):
     def visit_empty_set_expr(self, element_types):
         pass
 
-    def update_from_clause(
-        self, update_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+    def update_from_clause(self, update_stmt, from_table, extra_froms, from_hints, **kw):
         pass
 
-    def delete_extra_from_clause(
-        self, update_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+    def delete_extra_from_clause(self, update_stmt, from_table, extra_froms, from_hints, **kw):
         pass
 
 
@@ -43,3 +188,11 @@ class KustoSqlHttpsDialect(KustoBaseDialect):
     # doesn't work when defined in the KustoBaseDialect.
     # Need to investigate why it happens.
     supports_statement_cache = True
+
+    def __init__(self, max_top_n: int = 500_000, **kwargs):
+        super().__init__(**kwargs)
+        self.max_top_n = max_top_n
+
+    def do_execute(self, cursor, statement, parameters, context=None) -> None:
+        """Translate date_trunc() in raw SQL before the cursor sends it to Kusto."""
+        cursor.execute(_translate_raw_date_trunc(statement), parameters)

--- a/sqlalchemy_kusto/dialect_sql.py
+++ b/sqlalchemy_kusto/dialect_sql.py
@@ -3,120 +3,8 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.functions import GenericFunction
 
+from sqlalchemy_kusto.dbapi import _GRAIN_EPOCH, _GRAIN_TO_TSQL, _translate_raw_date_trunc  # noqa: F401
 from sqlalchemy_kusto.dialect_base import KustoBaseDialect
-
-# PostgreSQL date_trunc grain → T-SQL datepart name
-_GRAIN_TO_TSQL: dict[str, str] = {
-    "microseconds": "millisecond",  # T-SQL has no microsecond
-    "milliseconds": "millisecond",
-    "second": "second",
-    "minute": "minute",
-    "hour": "hour",
-    "day": "day",
-    "week": "week",
-    "week_sun": "week",  # extension: Sunday-based week (not in PostgreSQL)
-    "month": "month",
-    "quarter": "quarter",
-    "year": "year",
-}
-
-# Safe DATEDIFF base epoch per grain.
-# For sub-day grains, epoch 0 (1900-01-01) causes integer overflow; use 2000-01-01.
-# week_sun uses epoch -1 = 1899-12-31 (Sunday), so DATEADD/DATEDIFF stay in Sunday-aligned weeks.
-_GRAIN_EPOCH: dict[str, str] = {
-    "microseconds": "'2000-01-01'",
-    "milliseconds": "'2000-01-01'",
-    "second": "'2000-01-01'",
-    "minute": "'2000-01-01'",
-    "hour": "'2000-01-01'",
-    "day": "0",
-    "week": "0",
-    "week_sun": "-1",
-    "month": "0",
-    "quarter": "0",
-    "year": "0",
-}
-
-
-def _translate_raw_date_trunc(sql: str) -> str:
-    """Translate date_trunc('grain', expr) calls in a raw SQL string to T-SQL DATEADD/DATEDIFF.
-
-    Only the kustosql dialect calls this.  The kql dialect has its own compiler path.
-    Grain matching is case-insensitive.  Unknown grains are left unchanged.
-    """
-    marker = "date_trunc("
-    result: list[str] = []
-    i = 0
-    sql_lower = sql.lower()
-
-    while i < len(sql):
-        pos = sql_lower.find(marker, i)
-        if pos == -1:
-            result.append(sql[i:])
-            break
-
-        result.append(sql[i:pos])
-
-        # Walk forward tracking depth to find the matching ')'.
-        depth = 1
-        j = pos + len(marker)
-        while j < len(sql) and depth > 0:
-            if sql[j] == "(":
-                depth += 1
-            elif sql[j] == ")":
-                depth -= 1
-            j += 1
-
-        if depth != 0:
-            # Unbalanced parentheses — leave the rest unchanged.
-            result.append(sql[pos:])
-            i = len(sql)
-            break
-
-        interior = sql[pos + len(marker) : j - 1]
-
-        # Split interior at the first top-level comma to get grain and expression.
-        comma_pos: int | None = None
-        inner_depth = 0
-        for k, ch in enumerate(interior):
-            if ch == "(":
-                inner_depth += 1
-            elif ch == ")":
-                inner_depth -= 1
-            elif ch == "," and inner_depth == 0:
-                comma_pos = k
-                break
-
-        if comma_pos is None:
-            # Malformed call — leave unchanged.
-            result.append(sql[pos:j])
-            i = j
-            continue
-
-        grain_raw = interior[:comma_pos].strip().strip("'\"")
-        grain = grain_raw.lower()
-        expr = interior[comma_pos + 1 :].strip()
-
-        part = _GRAIN_TO_TSQL.get(grain)
-        if part is None:
-            # Unknown grain — leave the whole call unchanged.
-            result.append(sql[pos:j])
-            i = j
-            continue
-
-        epoch = _GRAIN_EPOCH.get(grain, "0")
-        if grain == "week":
-            # T-SQL DATEDIFF(week,...) counts Sunday boundaries, but epoch 0 is Monday.
-            # Shift the input back 1 day so Sunday stays inside its Mon-Sat week,
-            # producing ISO-standard Monday-based truncation (matches PostgreSQL semantics).
-            result.append(
-                f"DATEADD({part}, DATEDIFF({part}, {epoch}, DATEADD(day, -1, {expr})), {epoch})"
-            )
-        else:
-            result.append(f"DATEADD({part}, DATEDIFF({part}, {epoch}, {expr}), {epoch})")
-        i = j
-
-    return "".join(result)
 
 
 class date_trunc(GenericFunction):  # noqa: N801
@@ -192,7 +80,3 @@ class KustoSqlHttpsDialect(KustoBaseDialect):
     def __init__(self, max_top_n: int = 500_000, **kwargs):
         super().__init__(**kwargs)
         self.max_top_n = max_top_n
-
-    def do_execute(self, cursor, statement, parameters, context=None) -> None:
-        """Translate date_trunc() in raw SQL before the cursor sends it to Kusto."""
-        cursor.execute(_translate_raw_date_trunc(statement), parameters)

--- a/sqlalchemy_kusto/dialect_sql.py
+++ b/sqlalchemy_kusto/dialect_sql.py
@@ -1,9 +1,9 @@
-from sqlalchemy import types
+from sqlalchemy import exc, types
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.functions import GenericFunction
 
-from sqlalchemy_kusto.dbapi import _GRAIN_EPOCH, _GRAIN_TO_TSQL, _translate_raw_date_trunc  # noqa: F401
+from sqlalchemy_kusto.dbapi import _date_trunc_expr
 from sqlalchemy_kusto.dialect_base import KustoBaseDialect
 
 
@@ -18,23 +18,14 @@ class date_trunc(GenericFunction):  # noqa: N801
 @compiles(date_trunc, "kustosql")
 def _compile_date_trunc(element, compiler, **kw):
     grain_clause, col_clause = list(element.clauses)
+    grain = getattr(grain_clause, "value", None)
+    if grain is None:
+        grain = compiler.process(grain_clause, literal_binds=True, **kw)
 
-    if hasattr(grain_clause, "value"):
-        grain = str(grain_clause.value).strip("'\" ").lower()
-    else:
-        grain = compiler.process(grain_clause, literal_binds=True, **kw).strip("'\" ").lower()
-
-    t_sql_part = _GRAIN_TO_TSQL.get(grain, grain)
-    epoch = _GRAIN_EPOCH.get(grain, "0")
-    col = compiler.process(col_clause, **kw)
-
-    if grain == "week":
-        # T-SQL DATEDIFF(week,...) counts Sunday boundaries, but epoch 0 is Monday.
-        # Shift the input back 1 day so Sunday stays inside its Mon-Sat week,
-        # producing ISO-standard Monday-based truncation (matches PostgreSQL semantics).
-        return f"DATEADD({t_sql_part}, DATEDIFF({t_sql_part}, {epoch}, DATEADD(day, -1, {col})), {epoch})"
-
-    return f"DATEADD({t_sql_part}, DATEDIFF({t_sql_part}, {epoch}, {col}), {epoch})"
+    expression = _date_trunc_expr(str(grain), compiler.process(col_clause, **kw))
+    if expression is None:
+        raise exc.CompileError(f"Unsupported date_trunc grain for Kusto: {grain}")
+    return expression
 
 
 class KustoSqlCompiler(compiler.SQLCompiler):
@@ -46,7 +37,10 @@ class KustoSqlCompiler(compiler.SQLCompiler):
             kw["literal_execute"] = True
             select_precolumns += f"TOP {self.process(select._limit_clause, **kw)} "
         elif select._order_by_clauses:
-            # Kusto T-SQL requires a TOP clause when ORDER BY is present without LIMIT
+            # Kusto T-SQL drops ORDER BY unless the same SELECT also carries a TOP,
+            # which is how Superset loses sorting on the inner query of a wrapped SELECT.
+            # ponytail: silently caps the result at max_top_n rows; pass a bigger
+            # max_top_n to create_engine if a dataset can legitimately exceed it.
             select_precolumns += f"TOP {self.dialect.max_top_n} "
 
         return select_precolumns
@@ -61,10 +55,14 @@ class KustoSqlCompiler(compiler.SQLCompiler):
     def visit_empty_set_expr(self, element_types):
         pass
 
-    def update_from_clause(self, update_stmt, from_table, extra_froms, from_hints, **kw):
+    def update_from_clause(
+        self, update_stmt, from_table, extra_froms, from_hints, **kw
+    ):
         pass
 
-    def delete_extra_from_clause(self, update_stmt, from_table, extra_froms, from_hints, **kw):
+    def delete_extra_from_clause(
+        self, update_stmt, from_table, extra_froms, from_hints, **kw
+    ):
         pass
 
 
@@ -78,5 +76,10 @@ class KustoSqlHttpsDialect(KustoBaseDialect):
     supports_statement_cache = True
 
     def __init__(self, max_top_n: int = 500_000, **kwargs):
+        """Row cap used for ORDER BY without LIMIT.
+
+        Override per engine: create_engine(url, max_top_n=1_000_000). In Superset it
+        goes into the database's Advanced → Other → Engine Parameters.
+        """
         super().__init__(**kwargs)
         self.max_top_n = max_top_n

--- a/sqlalchemy_kusto/dialect_sql.py
+++ b/sqlalchemy_kusto/dialect_sql.py
@@ -36,11 +36,12 @@ class KustoSqlCompiler(compiler.SQLCompiler):
         if select._limit_clause is not None:
             kw["literal_execute"] = True
             select_precolumns += f"TOP {self.process(select._limit_clause, **kw)} "
-        elif select._order_by_clauses:
-            # Kusto T-SQL drops ORDER BY unless the same SELECT also carries a TOP,
-            # which is how Superset loses sorting on the inner query of a wrapped SELECT.
-            # ponytail: silently caps the result at max_top_n rows; pass a bigger
-            # max_top_n to create_engine if a dataset can legitimately exceed it.
+        elif select._order_by_clauses and len(self.stack) > 1:
+            # Kusto rejects ORDER BY inside a nested SELECT unless it also carries a
+            # TOP (verified against the Kusto emulator), and Superset's WRAP_SQL limit
+            # method produces exactly that shape. A top-level ORDER BY needs no TOP, so
+            # it must not get one — that would cap an otherwise unbounded query.
+            # ponytail: caps a nested sort at max_top_n rows; raise it via create_engine.
             select_precolumns += f"TOP {self.dialect.max_top_n} "
 
         return select_precolumns
@@ -76,10 +77,19 @@ class KustoSqlHttpsDialect(KustoBaseDialect):
     supports_statement_cache = True
 
     def __init__(self, max_top_n: int = 500_000, **kwargs):
-        """Row cap used for ORDER BY without LIMIT.
+        """Row cap used for a nested ORDER BY that has no LIMIT of its own.
 
         Override per engine: create_engine(url, max_top_n=1_000_000). In Superset it
         goes into the database's Advanced → Other → Engine Parameters.
         """
         super().__init__(**kwargs)
         self.max_top_n = max_top_n
+
+
+class KustoSqlHttpDialect(KustoSqlHttpsDialect):
+    """Plain-HTTP variant, for the Kusto emulator: no TLS, no authentication."""
+
+    driver = "http"
+    # SQLAlchemy looks this up on the concrete dialect class, not on its bases,
+    # which is also why KustoSqlHttpsDialect repeats it instead of inheriting it.
+    supports_statement_cache = True

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,20 @@
-import os
+"""Integration test setup.
 
+By default the tests run against a local Kusto emulator over plain HTTP:
+
+    make emulator      # starts the kustainer-linux container
+    make integration
+
+Set KUSTO_URL (and the AZURE_AD_* variables) to target a real cluster instead.
+When the endpoint is unreachable the suite is skipped rather than failed.
+"""
+
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+from azure.kusto.data import KustoConnectionStringBuilder
 from dotenv import load_dotenv
 from sqlalchemy.dialects import registry
 
@@ -7,14 +22,67 @@ registry.register(
     "kustosql.https", "sqlalchemy_kusto.dialect_sql", "KustoSqlHttpsDialect"
 )
 registry.register(
+    "kustosql.http", "sqlalchemy_kusto.dialect_sql", "KustoSqlHttpDialect"
+)
+registry.register(
     "kustokql.https", "sqlalchemy_kusto.dialect_kql", "KustoKqlHttpsDialect"
+)
+# The KQL dialect needs no HTTP subclass: the scheme comes from the URL, not the class.
+registry.register(
+    "kustokql.http", "sqlalchemy_kusto.dialect_kql", "KustoKqlHttpsDialect"
 )
 
 load_dotenv()
-AZURE_AD_CLIENT_ID = os.environ.get("AZURE_AD_CLIENT_ID", "")
-AZURE_AD_CLIENT_SECRET = os.environ.get("AZURE_AD_CLIENT_SECRET", "")
-AZURE_AD_TENANT_ID = os.environ.get("AZURE_AD_TENANT_ID", "")
-KUSTO_URL = os.environ["KUSTO_URL"]
+
+EMULATOR_URL = "http://localhost:8080"
+HTTP_OK = 200
+EMULATOR_DATABASE = "NetDefaultDB"
+
+
+def _env(name: str) -> str:
+    """Read an environment variable, treating the .env.sample placeholders as unset."""
+    value = os.environ.get(name, "").strip()
+    return "" if value.startswith("<") else value
+
+
+AZURE_AD_CLIENT_ID = _env("AZURE_AD_CLIENT_ID")
+AZURE_AD_CLIENT_SECRET = _env("AZURE_AD_CLIENT_SECRET")
+AZURE_AD_TENANT_ID = _env("AZURE_AD_TENANT_ID")
+KUSTO_URL = _env("KUSTO_URL") or EMULATOR_URL
 KUSTO_SQL_ALCHEMY_URL = "kustosql+" + KUSTO_URL
 KUSTO_KQL_ALCHEMY_URL = "kustokql+" + KUSTO_URL
-DATABASE = os.environ["DATABASE"]
+
+# Plain HTTP means the emulator, which has no authentication whatsoever.
+USES_EMULATOR = KUSTO_URL.startswith("http://")
+DATABASE = EMULATOR_DATABASE if USES_EMULATOR else _env("DATABASE")
+
+
+def get_kcsb() -> KustoConnectionStringBuilder:
+    """Connection string for the raw client the fixtures use to set up test data."""
+    if USES_EMULATOR:
+        return KustoConnectionStringBuilder(KUSTO_URL)
+    if AZURE_AD_CLIENT_ID and AZURE_AD_CLIENT_SECRET and AZURE_AD_TENANT_ID:
+        return KustoConnectionStringBuilder.with_aad_application_key_authentication(
+            KUSTO_URL, AZURE_AD_CLIENT_ID, AZURE_AD_CLIENT_SECRET, AZURE_AD_TENANT_ID
+        )
+    return KustoConnectionStringBuilder.with_az_cli_authentication(KUSTO_URL)
+
+
+def _emulator_is_up() -> bool:
+    request = urllib.request.Request(
+        f"{KUSTO_URL}/v1/rest/mgmt",
+        data=b'{"csl":".show cluster"}',
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status == HTTP_OK
+    except OSError:
+        return False
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_kusto():
+    """Skip the suite instead of failing it when there is nothing to talk to."""
+    if USES_EMULATOR and not _emulator_is_up():
+        pytest.skip(f"Kusto emulator unreachable at {KUSTO_URL}; run `make emulator`")

--- a/tests/integration/test_dialect_kql.py
+++ b/tests/integration/test_dialect_kql.py
@@ -6,11 +6,7 @@ import io
 
 import pytest
 import sqlalchemy.types
-from azure.kusto.data import (
-    ClientRequestProperties,
-    KustoClient,
-    KustoConnectionStringBuilder,
-)
+from azure.kusto.data import ClientRequestProperties, KustoClient
 from sqlalchemy import (
     Column,
     MetaData,
@@ -29,16 +25,21 @@ from tests.integration.conftest import (
     AZURE_AD_TENANT_ID,
     DATABASE,
     KUSTO_KQL_ALCHEMY_URL,
-    KUSTO_URL,
+    USES_EMULATOR,
+    get_kcsb,
 )
 
 logger = logging.getLogger(__name__)
 
 kql_engine = create_engine(
-    f"{KUSTO_KQL_ALCHEMY_URL}/{DATABASE}?"
-    f"msi=False&azure_ad_client_id={AZURE_AD_CLIENT_ID}&"
-    f"azure_ad_client_secret={AZURE_AD_CLIENT_SECRET}&"
-    f"azure_ad_tenant_id={AZURE_AD_TENANT_ID}"
+    f"{KUSTO_KQL_ALCHEMY_URL}/{DATABASE}"
+    if USES_EMULATOR
+    else (
+        f"{KUSTO_KQL_ALCHEMY_URL}/{DATABASE}?"
+        f"msi=False&azure_ad_client_id={AZURE_AD_CLIENT_ID}&"
+        f"azure_ad_client_secret={AZURE_AD_CLIENT_SECRET}&"
+        f"azure_ad_tenant_id={AZURE_AD_TENANT_ID}"
+    )
 )
 
 Session = sessionmaker(bind=kql_engine)
@@ -200,18 +201,6 @@ def test_date_bin_ops(test_label, group_fn, temp_table_name, expected, compare_d
             else {expected}
         )
         assert actual_result == expected_records
-
-
-def get_kcsb():
-    return (
-        KustoConnectionStringBuilder.with_az_cli_authentication(KUSTO_URL)
-        if not AZURE_AD_CLIENT_ID
-        and not AZURE_AD_CLIENT_SECRET
-        and not AZURE_AD_TENANT_ID
-        else KustoConnectionStringBuilder.with_aad_application_key_authentication(
-            KUSTO_URL, AZURE_AD_CLIENT_ID, AZURE_AD_CLIENT_SECRET, AZURE_AD_TENANT_ID
-        )
-    )
 
 
 def _create_temp_table(table_name: str):

--- a/tests/integration/test_dialect_sql.py
+++ b/tests/integration/test_dialect_sql.py
@@ -149,6 +149,18 @@ def test_nested_order_by_is_sorted(temp_table_name):
     assert len(ids) == NESTED_LIMIT
 
 
+def test_ilike_matches_case_insensitively(temp_table_name):
+    """Superset's filter search compiles to ilike; Kusto rejects the stock
+    lower(x) LIKE lower(y) form (OTR0001: LIKE pattern is not a string), so the
+    dialect emits plain LIKE and relies on Kusto matching case-insensitively.
+    """
+    table = _table(temp_table_name)
+
+    engine.connect()
+    result = engine.execute(table.select().where(table.c.Text.ilike("%VALUE_1%")))
+    assert [row[1] for row in result.fetchall()] == ["value_1"]
+
+
 def test_nested_order_by_without_top_is_rejected_by_kusto(temp_table_name):
     """Why the TOP fallback exists: Kusto refuses this shape outright.
 

--- a/tests/integration/test_dialect_sql.py
+++ b/tests/integration/test_dialect_sql.py
@@ -20,6 +20,7 @@ from tests.integration.conftest import (
     AZURE_AD_CLIENT_SECRET,
     AZURE_AD_TENANT_ID,
     DATABASE,
+    KUSTO_KQL_ALCHEMY_URL,
     KUSTO_SQL_ALCHEMY_URL,
     USES_EMULATOR,
     get_kcsb,
@@ -39,6 +40,7 @@ engine = create_engine(
 
 ROW_COUNT = 9  # rows the fixture ingests into the temp table
 NESTED_LIMIT = 5  # outer limit used by the wrapped-query tests
+EVENTS_ROW_COUNT = 3  # rows in the datetime fixture
 
 
 def test_ping():
@@ -208,6 +210,67 @@ def test_unsupported_date_trunc_grain_is_rejected(temp_events_table, grain: str)
         engine.execute(
             f"select top 1 date_trunc('{grain}', Ts) from {temp_events_table}"
         ).fetchall()
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        # spellings analysts actually used in production SQLLab queries
+        ("DATETRUNC('hour', Ts)", datetime(2024, 5, 17, 10, 0)),
+        ("DATETRUNC(month, Ts)", datetime(2024, 5, 1)),
+        ("startofday(Ts)", datetime(2024, 5, 17)),
+        ("startofmonth(Ts)", datetime(2024, 5, 1)),
+        ("startofweek(Ts)", datetime(2024, 5, 12)),  # KQL weeks start on Sunday
+        ("DATE(Ts)", datetime(2024, 5, 17)),
+        ("to_date(Ts)", datetime(2024, 5, 17)),
+    ],
+)
+def test_translated_date_functions(
+    temp_events_table, expression: str, expected: datetime
+):
+    """Functions Kusto rejects verbatim must work through the translation."""
+    engine.connect()
+    result = engine.execute(
+        f"select top 1 {expression} as value from {temp_events_table} order by Ts"
+    )
+    assert result.fetchone()[0].replace(tzinfo=None) == expected
+
+
+def test_translated_scalar_functions(temp_events_table):
+    """date_part and ifnull have exact T-SQL equivalents; check both on real data."""
+    engine.connect()
+    row = engine.execute(
+        f"select top 1 DATE_PART(hour, Ts) as h, IFNULL(Id, -1) as i "
+        f"from {temp_events_table} order by Ts"
+    ).fetchone()
+    assert (row[0], row[1]) == (10, 1)
+
+
+def test_cte_is_sent_as_tsql(temp_events_table):
+    """A query starting with WITH used to be sent as KQL and fail before reaching SQL."""
+    engine.connect()
+    result = engine.execute(
+        f"with daily as (select date_trunc('day', Ts) as d from {temp_events_table}) "
+        f"select top 1 d from daily order by d"
+    )
+    assert result.fetchone()[0].replace(tzinfo=None) == datetime(2024, 5, 17)
+
+
+def test_kql_query_still_runs_on_the_kql_dialect(temp_events_table):
+    """The SQL/KQL split must not misroute a KQL query that starts with a table name."""
+    kql_engine = create_engine(
+        f"{KUSTO_KQL_ALCHEMY_URL}/{DATABASE}"
+        if USES_EMULATOR
+        else (
+            f"{KUSTO_KQL_ALCHEMY_URL}/{DATABASE}?"
+            f"msi=False&azure_ad_client_id={AZURE_AD_CLIENT_ID}&"
+            f"azure_ad_client_secret={AZURE_AD_CLIENT_SECRET}&"
+            f"azure_ad_tenant_id={AZURE_AD_TENANT_ID}"
+        )
+    )
+    kql_engine.connect()
+    rows = kql_engine.execute(f"{temp_events_table} | count").fetchall()
+    assert rows[0][0] == EVENTS_ROW_COUNT
 
 
 def _create_temp_table(table_name: str):

--- a/tests/integration/test_dialect_sql.py
+++ b/tests/integration/test_dialect_sql.py
@@ -99,6 +99,53 @@ def test_limit(temp_table_name):
     assert result_length == limit_rec_count
 
 
+def test_order_by_without_limit_is_actually_sorted(temp_table_name):
+    """Kusto keeps ORDER BY only when the SELECT also has a TOP; the dialect adds one."""
+    stream = Table(
+        temp_table_name,
+        MetaData(),
+        Column("Id", Integer),
+        Column("Text", String),
+    )
+
+    engine.connect()
+    result = engine.execute(stream.select().order_by(stream.c.Id.desc()))
+    ids = [row[0] for row in result.fetchall()]
+    assert ids == sorted(ids, reverse=True)
+
+
+def test_order_by_inside_wrapped_query_is_sorted(temp_table_name):
+    """Reproduces Superset's shape: outer SELECT with a limit over an ordered inner one."""
+    inner = f"(select * from {temp_table_name} order by Id desc)"
+
+    engine.connect()
+    result = engine.execute(f"select top 5 Id from {inner} as inner_qry")
+    ids = [row[0] for row in result.fetchall()]
+    assert ids == sorted(ids, reverse=True)
+
+
+@pytest.mark.parametrize(
+    ("grain", "expected"),
+    [
+        ("day", "2024-05-17 00:00:00"),
+        ("month", "2024-05-01 00:00:00"),
+        ("year", "2024-01-01 00:00:00"),
+        ("week", "2024-05-13 00:00:00"),  # Monday of that week
+        ("week_sun", "2024-05-12 00:00:00"),  # Sunday of that week
+        ("hour", "2024-05-17 10:00:00"),
+    ],
+)
+def test_raw_date_trunc(temp_table_name, grain: str, expected: str):
+    """date_trunc() written by hand in SQLLab must reach Kusto as DATEADD/DATEDIFF."""
+    engine.connect()
+    result = engine.execute(
+        f"select top 1 date_trunc('{grain}', "
+        f"CONVERT(DATETIME, '2024-05-17T10:30:45', 126)) as truncated "
+        f"from {temp_table_name}"
+    )
+    assert str(result.fetchone()[0]) == expected
+
+
 def get_kcsb():
     return (
         KustoConnectionStringBuilder.with_az_cli_authentication(KUSTO_URL)

--- a/tests/integration/test_dialect_sql.py
+++ b/tests/integration/test_dialect_sql.py
@@ -1,28 +1,44 @@
 import uuid
+from datetime import datetime
 
 import pytest
-from azure.kusto.data import (
-    ClientRequestProperties,
-    KustoClient,
-    KustoConnectionStringBuilder,
+from azure.kusto.data import ClientRequestProperties, KustoClient
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    exc,
+    func,
+    select,
 )
-from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
-
 from tests.integration.conftest import (
     AZURE_AD_CLIENT_ID,
     AZURE_AD_CLIENT_SECRET,
     AZURE_AD_TENANT_ID,
     DATABASE,
     KUSTO_SQL_ALCHEMY_URL,
-    KUSTO_URL,
+    USES_EMULATOR,
+    get_kcsb,
 )
 
 engine = create_engine(
-    f"{KUSTO_SQL_ALCHEMY_URL}/{DATABASE}?"
-    f"msi=False&azure_ad_client_id={AZURE_AD_CLIENT_ID}&"
-    f"azure_ad_client_secret={AZURE_AD_CLIENT_SECRET}&"
-    f"azure_ad_tenant_id={AZURE_AD_TENANT_ID}"
+    f"{KUSTO_SQL_ALCHEMY_URL}/{DATABASE}"
+    if USES_EMULATOR
+    else (
+        f"{KUSTO_SQL_ALCHEMY_URL}/{DATABASE}?"
+        f"msi=False&azure_ad_client_id={AZURE_AD_CLIENT_ID}&"
+        f"azure_ad_client_secret={AZURE_AD_CLIENT_SECRET}&"
+        f"azure_ad_tenant_id={AZURE_AD_TENANT_ID}"
+    )
 )
+
+
+ROW_COUNT = 9  # rows the fixture ingests into the temp table
+NESTED_LIMIT = 5  # outer limit used by the wrapped-query tests
 
 
 def test_ping():
@@ -99,63 +115,99 @@ def test_limit(temp_table_name):
     assert result_length == limit_rec_count
 
 
-def test_order_by_without_limit_is_actually_sorted(temp_table_name):
-    """Kusto keeps ORDER BY only when the SELECT also has a TOP; the dialect adds one."""
-    stream = Table(
-        temp_table_name,
+def _table(name: str) -> Table:
+    return Table(
+        name,
         MetaData(),
         Column("Id", Integer),
         Column("Text", String),
     )
 
-    engine.connect()
-    result = engine.execute(stream.select().order_by(stream.c.Id.desc()))
-    ids = [row[0] for row in result.fetchall()]
-    assert ids == sorted(ids, reverse=True)
 
-
-def test_order_by_inside_wrapped_query_is_sorted(temp_table_name):
-    """Reproduces Superset's shape: outer SELECT with a limit over an ordered inner one."""
-    inner = f"(select * from {temp_table_name} order by Id desc)"
+def test_top_level_order_by_is_sorted(temp_table_name):
+    """A top-level ORDER BY needs no TOP, so the dialect must not add one."""
+    table = _table(temp_table_name)
 
     engine.connect()
-    result = engine.execute(f"select top 5 Id from {inner} as inner_qry")
+    result = engine.execute(table.select().order_by(table.c.Id.desc()))
     ids = [row[0] for row in result.fetchall()]
     assert ids == sorted(ids, reverse=True)
+    assert len(ids) == ROW_COUNT  # nothing was capped away
+
+
+def test_nested_order_by_is_sorted(temp_table_name):
+    """Superset's WRAP_SQL shape: outer limit over an inner ordered SELECT."""
+    table = _table(temp_table_name)
+    inner = table.select().order_by(table.c.Id.desc()).alias("virtual_table")
+
+    engine.connect()
+    result = engine.execute(inner.select().limit(NESTED_LIMIT))
+    ids = [row[0] for row in result.fetchall()]
+    assert ids == sorted(ids, reverse=True)
+    assert len(ids) == NESTED_LIMIT
+
+
+def test_nested_order_by_without_top_is_rejected_by_kusto(temp_table_name):
+    """Why the TOP fallback exists: Kusto refuses this shape outright.
+
+    If this ever starts passing, Kusto changed and the fallback can be reconsidered.
+    """
+    engine.connect()
+    with pytest.raises(exc.DatabaseError):
+        engine.execute(
+            f"select top 5 Id from (select Id from {temp_table_name} order by Id desc) as v"
+        ).fetchall()
 
 
 @pytest.mark.parametrize(
     ("grain", "expected"),
     [
-        ("day", "2024-05-17 00:00:00"),
-        ("month", "2024-05-01 00:00:00"),
-        ("year", "2024-01-01 00:00:00"),
-        ("week", "2024-05-13 00:00:00"),  # Monday of that week
-        ("week_sun", "2024-05-12 00:00:00"),  # Sunday of that week
-        ("hour", "2024-05-17 10:00:00"),
+        ("second", datetime(2024, 5, 17, 10, 30, 45)),
+        ("minute", datetime(2024, 5, 17, 10, 30)),
+        ("hour", datetime(2024, 5, 17, 10, 0)),
+        ("day", datetime(2024, 5, 17)),
+        ("week", datetime(2024, 5, 13)),  # Monday of that week
+        ("week_sun", datetime(2024, 5, 12)),  # Sunday of that week
+        ("month", datetime(2024, 5, 1)),
+        ("quarter", datetime(2024, 4, 1)),
+        ("year", datetime(2024, 1, 1)),
     ],
 )
-def test_raw_date_trunc(temp_table_name, grain: str, expected: str):
-    """date_trunc() written by hand in SQLLab must reach Kusto as DATEADD/DATEDIFF."""
+def test_raw_date_trunc(temp_events_table, grain: str, expected: datetime):
+    """date_trunc() typed by hand in SQLLab must reach Kusto as DATEADD/DATEDIFF."""
     engine.connect()
     result = engine.execute(
-        f"select top 1 date_trunc('{grain}', "
-        f"CONVERT(DATETIME, '2024-05-17T10:30:45', 126)) as truncated "
-        f"from {temp_table_name}"
+        f"select top 1 date_trunc('{grain}', Ts) as truncated "
+        f"from {temp_events_table} order by Ts"
     )
-    assert str(result.fetchone()[0]) == expected
+    assert result.fetchone()[0].replace(tzinfo=None) == expected
 
 
-def get_kcsb():
-    return (
-        KustoConnectionStringBuilder.with_az_cli_authentication(KUSTO_URL)
-        if not AZURE_AD_CLIENT_ID
-        and not AZURE_AD_CLIENT_SECRET
-        and not AZURE_AD_TENANT_ID
-        else KustoConnectionStringBuilder.with_aad_application_key_authentication(
-            KUSTO_URL, AZURE_AD_CLIENT_ID, AZURE_AD_CLIENT_SECRET, AZURE_AD_TENANT_ID
-        )
+def test_compiled_date_trunc(temp_events_table):
+    """The same grain, this time going through func.date_trunc and the dialect hook."""
+    events = Table(
+        temp_events_table,
+        MetaData(),
+        Column("Id", Integer),
+        Column("Ts", DateTime),
     )
+
+    engine.connect()
+    query = (
+        select([func.date_trunc("week", events.c.Ts)]).order_by(events.c.Ts).limit(1)
+    )
+    truncated = engine.execute(query).fetchone()[0]
+    assert truncated.replace(tzinfo=None) == datetime(2024, 5, 13)
+
+
+@pytest.mark.parametrize("grain", ["milliseconds", "decade"])
+def test_unsupported_date_trunc_grain_is_rejected(temp_events_table, grain: str):
+    """Unsupported grains reach Kusto untouched and fail loudly instead of silently."""
+    engine.connect()
+    with pytest.raises(exc.DatabaseError):
+        engine.execute(
+            f"select top 1 date_trunc('{grain}', Ts) from {temp_events_table}"
+        ).fetchall()
 
 
 def _create_temp_table(table_name: str):
@@ -178,7 +230,7 @@ def _create_temp_fn(fn_name: str):
 
 def _ingest_data_to_table(table_name: str):
     client = KustoClient(get_kcsb())
-    data_to_ingest = {i: "value_" + str(i) for i in range(1, 10)}
+    data_to_ingest = {i: "value_" + str(i) for i in range(1, ROW_COUNT + 1)}
     str_data = "\n".join("{},{}".format(*p) for p in data_to_ingest.items())
     ingest_query = f""".ingest inline into table {table_name} <|
             {str_data}"""
@@ -207,3 +259,29 @@ def run_around_tests(temp_table_name):
     # A test function will be run at this point
     yield temp_table_name
     _drop_table(temp_table_name)
+
+
+@pytest.fixture
+def temp_events_table():
+    """Table with a datetime column, for the date_trunc tests.
+
+    Timestamps straddle a week boundary so Monday-based and Sunday-based truncation
+    give different answers: 2024-05-17 is a Friday, 05-13 its Monday, 05-12 its Sunday.
+    """
+    table_name = "_events_" + uuid.uuid4().hex
+    client = KustoClient(get_kcsb())
+    client.execute(
+        DATABASE,
+        f".create table {table_name}(Id: int, Ts: datetime)",
+        ClientRequestProperties(),
+    )
+    client.execute(
+        DATABASE,
+        f".ingest inline into table {table_name} <|\n"
+        "1,2024-05-17T10:30:45\n"
+        "2,2024-05-18T23:59:59\n"
+        "3,2024-05-20T00:00:01",
+        ClientRequestProperties(),
+    )
+    yield table_name
+    client.execute(DATABASE, f".drop table {table_name}", ClientRequestProperties())

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -2,9 +2,16 @@ import pytest
 import sqlalchemy
 from sqlalchemy import create_engine
 
-from tests.integration.conftest import DATABASE, KUSTO_SQL_ALCHEMY_URL
+from tests.integration.conftest import (
+    DATABASE,
+    KUSTO_SQL_ALCHEMY_URL,
+    USES_EMULATOR,
+)
 
 
+@pytest.mark.skipif(
+    USES_EMULATOR, reason="the emulator has no authentication, so it cannot fail on it"
+)
 def test_operational_error() -> None:
     wrong_tenant_id = "wrong_tenant_id"
     azure_ad_client_id = "x"

--- a/tests/unit/test_dialect_sql.py
+++ b/tests/unit/test_dialect_sql.py
@@ -66,46 +66,50 @@ def test_boolean_filter_full_query():
 
 
 class TestOrderByWithoutLimit:
-    """Kusto drops ORDER BY unless the same SELECT carries a TOP."""
+    """Kusto rejects ORDER BY in a nested SELECT that has no TOP; top level is fine."""
 
     events = Table("events", MetaData(), Column("score", Integer))
 
-    def test_order_by_without_limit_inserts_top_fallback(self):
-        sql = _compile(
-            select([self.events.c.score]).order_by(self.events.c.score.desc())
-        )
-        assert "TOP 500000" in sql
+    def _ordered(self):
+        return select([self.events.c.score]).order_by(self.events.c.score.desc())
+
+    def test_top_level_order_by_gets_no_top(self):
+        """Kusto sorts a top-level ORDER BY on its own: a TOP would only cap the result."""
+        sql = _compile(self._ordered())
         assert "ORDER BY" in sql
+        assert "TOP" not in sql
 
     def test_order_by_with_limit_uses_limit_not_double_top(self):
-        query = (
-            select([self.events.c.score]).order_by(self.events.c.score.desc()).limit(10)
-        )
-        sql = _compile(query)
+        sql = _compile(self._ordered().limit(10))
         assert sql.count("TOP") == 1
         assert "TOP 10" in sql
 
     def test_select_without_order_by_no_extra_top(self):
         assert "TOP" not in _compile(select([self.events.c.score]))
 
-    def test_inner_order_by_survives_outer_limit(self):
-        """Superset wraps the query; the inner ORDER BY needs its own TOP."""
-        inner = (
-            select([self.events.c.score])
-            .order_by(self.events.c.score.desc())
-            .alias("v")
-        )
-        sql = _compile(select([inner.c.score]).limit(100))
+    def test_nested_order_by_gets_top(self):
+        """Superset's WRAP_SQL shape: the inner ORDER BY needs a TOP of its own."""
+        sql = _compile(select([self._ordered().alias("virtual_table")]).limit(100))
         assert "TOP 500000" in sql
         assert "TOP 100" in sql
         assert "ORDER BY" in sql
+
+    def test_nested_order_by_with_own_limit_keeps_it(self):
+        inner = self._ordered().limit(20).alias("virtual_table")
+        sql = _compile(select([inner]).limit(100))
+        assert "TOP 20" in sql
+        assert "TOP 500000" not in sql
+
+    def test_nested_select_without_order_by_gets_no_top(self):
+        inner = select([self.events.c.score]).alias("virtual_table")
+        assert "TOP" not in _compile(select([inner]))
 
     def test_top_fallback_value_is_configurable(self):
         """max_top_n must be settable the way callers actually set it."""
         custom_engine = create_engine(
             "kustosql+https://localhost/testdb", max_top_n=999
         )
-        query = select([self.events.c.score]).order_by(self.events.c.score.desc())
+        query = select([self._ordered().alias("virtual_table")]).limit(100)
         assert "TOP 999" in _compile(query, custom_engine)
 
 

--- a/tests/unit/test_dialect_sql.py
+++ b/tests/unit/test_dialect_sql.py
@@ -263,30 +263,28 @@ class TestTranslateRawDateTrunc:
         assert "date_trunc('hour', ts)" in result
 
 
-class TestKustoSqlDialectDoExecute:
-    """KustoSqlHttpsDialect.do_execute must translate date_trunc before the cursor sees the SQL."""
+class TestCursorDateTruncTranslation:
+    """Cursor.execute must translate date_trunc before sending SQL to Kusto."""
 
-    def _dialect(self) -> KustoSqlHttpsDialect:
-        return KustoSqlHttpsDialect()
+    def _cursor(self):
+        from sqlalchemy_kusto.dbapi import Cursor
 
-    def test_date_trunc_translated_before_cursor(self):
-        cursor = MagicMock()
-        self._dialect().do_execute(
-            cursor, "SELECT date_trunc('day', ts) FROM t", [], context=None
-        )
-        cursor.execute.assert_called_once()
-        received_sql: str = cursor.execute.call_args[0][0]
+        client = MagicMock()
+        response = MagicMock()
+        response.primary_results = [MagicMock(columns=[], **{"__iter__": lambda s: iter([])})]
+        client.execute.return_value = response
+        return Cursor(client, "testdb"), client
+
+    def test_date_trunc_translated_before_kusto(self):
+        cursor, client = self._cursor()
+        cursor.execute("SELECT date_trunc('day', ts) FROM t")
+        received_sql: str = client.execute.call_args[0][1]
         assert "DATEADD(day" in received_sql
         assert "date_trunc(" not in received_sql.lower()
 
-    def test_parameters_forwarded_unchanged(self):
-        cursor = MagicMock()
-        params = {"id": 42}
-        self._dialect().do_execute(cursor, "SELECT id FROM t", params, context=None)
-        cursor.execute.assert_called_once_with("SELECT id FROM t", params)
-
     def test_sql_without_date_trunc_forwarded_unchanged(self):
-        cursor = MagicMock()
+        cursor, client = self._cursor()
         sql = "SELECT id, name FROM users WHERE active = 1"
-        self._dialect().do_execute(cursor, sql, [], context=None)
-        cursor.execute.assert_called_once_with(sql, [])
+        cursor.execute(sql)
+        received_sql: str = client.execute.call_args[0][1]
+        assert received_sql.rstrip() == sql

--- a/tests/unit/test_dialect_sql.py
+++ b/tests/unit/test_dialect_sql.py
@@ -1,4 +1,15 @@
+from __future__ import annotations
 from sqlalchemy import Boolean, Column, Integer, MetaData, Table, create_engine, select
+
+from unittest.mock import MagicMock
+
+from sqlalchemy import DateTime, func
+
+from sqlalchemy_kusto.dialect_sql import KustoSqlHttpsDialect, _translate_raw_date_trunc
+
+engine = create_engine("kustosql+https://localhost/testdb")
+
+
 
 engine = create_engine("kustosql+https://localhost/testdb")
 
@@ -41,3 +52,241 @@ def test_boolean_filter_full_query():
     sql = str(query.compile(engine, compile_kwargs={"literal_binds": True}))
     assert "false" not in sql.lower()
     assert "true" not in sql.lower()
+
+def _compile(query) -> str:
+    return str(query.compile(engine, compile_kwargs={"literal_binds": True})).replace("\n", " ")
+
+
+class TestOrderByWithoutLimit:
+    def test_order_by_without_limit_inserts_top_fallback(self):
+        t = Table("events", MetaData(), Column("score", Integer))
+        query = select([t.c.score]).order_by(t.c.score.desc())
+        sql = _compile(query)
+        assert "TOP" in sql
+        assert "ORDER BY" in sql
+
+    def test_order_by_with_limit_uses_limit_not_double_top(self):
+        t = Table("events", MetaData(), Column("score", Integer))
+        query = select([t.c.score]).order_by(t.c.score.desc()).limit(10)
+        sql = _compile(query)
+        assert sql.count("TOP") == 1
+        assert "TOP 10" in sql
+
+    def test_select_without_order_by_no_extra_top(self):
+        t = Table("events", MetaData(), Column("score", Integer))
+        query = select([t.c.score])
+        sql = _compile(query)
+        assert "TOP" not in sql
+
+    def test_top_fallback_value_is_configurable(self):
+        custom_engine = create_engine("kustosql+https://localhost/testdb", connect_args={})
+        custom_engine.dialect.max_top_n = 999
+        t = Table("events", MetaData(), Column("score", Integer))
+        query = select([t.c.score]).order_by(t.c.score.desc())
+        sql = str(query.compile(custom_engine, compile_kwargs={"literal_binds": True}))
+        assert "TOP 999" in sql
+
+
+class TestDateTrunc:
+    def _query(self, grain: str) -> str:
+        t = Table("events", MetaData(), Column("ts", DateTime))
+        query = select([func.date_trunc(grain, t.c.ts)])
+        return _compile(query)
+
+    def test_date_trunc_day(self):
+        sql = self._query("day")
+        assert "DATEADD(day" in sql
+        assert "DATEDIFF(day" in sql
+
+    def test_date_trunc_month(self):
+        sql = self._query("month")
+        assert "DATEADD(month" in sql
+        assert "DATEDIFF(month" in sql
+
+    def test_date_trunc_year(self):
+        sql = self._query("year")
+        assert "DATEADD(year" in sql
+        assert "DATEDIFF(year" in sql
+
+    def test_date_trunc_hour(self):
+        sql = self._query("hour")
+        assert "DATEADD(hour" in sql
+        assert "DATEDIFF(hour" in sql
+
+    def test_date_trunc_minute(self):
+        sql = self._query("minute")
+        assert "DATEADD(minute" in sql
+        assert "DATEDIFF(minute" in sql
+
+    def test_date_trunc_week(self):
+        sql = self._query("week")
+        # Must use the DATEADD(day,-1,...) shift for Monday-based ISO weeks
+        assert "DATEADD(week" in sql
+        assert "DATEDIFF(week" in sql
+        assert "DATEADD(day, -1," in sql
+
+    def test_date_trunc_week_sun(self):
+        sql = self._query("week_sun")
+        # Sunday-based: uses epoch -1 (1899-12-31 = Sunday), no day shift
+        assert "DATEADD(week" in sql
+        assert "DATEDIFF(week" in sql
+        assert ", -1," in sql or ", -1)" in sql
+        assert "DATEADD(day, -1," not in sql
+
+    def test_date_trunc_quarter(self):
+        sql = self._query("quarter")
+        assert "DATEADD(quarter" in sql
+        assert "DATEDIFF(quarter" in sql
+
+    def test_date_trunc_not_passed_through_verbatim(self):
+        sql = self._query("day")
+        assert "date_trunc(" not in sql.lower()
+
+    def test_date_trunc_minute_uses_safe_epoch(self):
+        sql = self._query("minute")
+        assert "2000-01-01" in sql
+
+    def test_date_trunc_day_uses_zero_epoch(self):
+        sql = self._query("day")
+        assert ", 0," in sql or ", 0)" in sql
+
+
+class TestTranslateRawDateTrunc:
+    """_translate_raw_date_trunc rewrites date_trunc() in a raw SQL string."""
+
+    def test_day_grain(self):
+        sql = "SELECT date_trunc('day', event_time) FROM events"
+        assert _translate_raw_date_trunc(sql) == (
+            "SELECT DATEADD(day, DATEDIFF(day, 0, event_time), 0) FROM events"
+        )
+
+    def test_month_grain(self):
+        sql = "SELECT date_trunc('month', ts) FROM t"
+        result = _translate_raw_date_trunc(sql)
+        assert result == "SELECT DATEADD(month, DATEDIFF(month, 0, ts), 0) FROM t"
+
+    def test_year_grain(self):
+        sql = "SELECT date_trunc('year', ts) FROM t"
+        result = _translate_raw_date_trunc(sql)
+        assert result == "SELECT DATEADD(year, DATEDIFF(year, 0, ts), 0) FROM t"
+
+    def test_week_grain(self):
+        sql = "SELECT date_trunc('week', ts) FROM t"
+        result = _translate_raw_date_trunc(sql)
+        assert result == "SELECT DATEADD(week, DATEDIFF(week, 0, DATEADD(day, -1, ts)), 0) FROM t"
+
+    def test_quarter_grain(self):
+        sql = "SELECT date_trunc('quarter', ts) FROM t"
+        result = _translate_raw_date_trunc(sql)
+        assert result == "SELECT DATEADD(quarter, DATEDIFF(quarter, 0, ts), 0) FROM t"
+
+    def test_hour_grain_uses_safe_epoch(self):
+        """Sub-day grains must use '2000-01-01' to avoid DATEDIFF integer overflow."""
+        sql = "SELECT date_trunc('hour', ts) FROM logs"
+        result = _translate_raw_date_trunc(sql)
+        assert result == (
+            "SELECT DATEADD(hour, DATEDIFF(hour, '2000-01-01', ts), '2000-01-01') FROM logs"
+        )
+
+    def test_minute_grain_uses_safe_epoch(self):
+        sql = "SELECT date_trunc('minute', ts) FROM logs"
+        result = _translate_raw_date_trunc(sql)
+        assert "DATEADD(minute" in result
+        assert "'2000-01-01'" in result
+
+    def test_second_grain_uses_safe_epoch(self):
+        sql = "SELECT date_trunc('second', ts) FROM logs"
+        result = _translate_raw_date_trunc(sql)
+        assert "DATEADD(second" in result
+        assert "'2000-01-01'" in result
+
+    def test_milliseconds_grain_maps_to_millisecond(self):
+        """'milliseconds' (plural) maps to T-SQL 'millisecond' (singular)."""
+        sql = "SELECT date_trunc('milliseconds', ts) FROM logs"
+        result = _translate_raw_date_trunc(sql)
+        assert "DATEADD(millisecond," in result
+        assert "'2000-01-01'" in result
+
+    def test_microseconds_grain_maps_to_millisecond(self):
+        """'microseconds' maps to 'millisecond' — T-SQL has no microsecond datepart."""
+        sql = "SELECT date_trunc('microseconds', ts) FROM logs"
+        result = _translate_raw_date_trunc(sql)
+        assert "DATEADD(millisecond," in result
+
+    def test_grain_capitalisation_normalised(self):
+        """Grain is case-insensitive — 'Day' and 'DAY' must work like 'day'."""
+        for grain in ("Day", "DAY", "dAy"):
+            sql = f"SELECT date_trunc('{grain}', ts) FROM t"
+            result = _translate_raw_date_trunc(sql)
+            assert "DATEADD(day" in result, f"Failed for grain={grain!r}: {result}"
+
+    def test_nested_parens_in_expr(self):
+        """Expressions containing parentheses must be preserved intact."""
+        sql = "SELECT date_trunc('day', CAST(ts AS DATETIME)) FROM logs"
+        result = _translate_raw_date_trunc(sql)
+        assert result == (
+            "SELECT DATEADD(day, DATEDIFF(day, 0, CAST(ts AS DATETIME)), 0) FROM logs"
+        )
+
+    def test_multiple_calls_in_one_query(self):
+        """Every occurrence is translated."""
+        sql = "SELECT date_trunc('day', a), date_trunc('hour', b) FROM t"
+        result = _translate_raw_date_trunc(sql)
+        assert "DATEADD(day" in result
+        assert "DATEADD(hour" in result
+        assert "date_trunc(" not in result.lower()
+
+    def test_week_sun_grain(self):
+        """week_sun uses epoch -1 (Sunday) with no day shift."""
+        sql = "SELECT date_trunc('week_sun', ts) FROM t"
+        result = _translate_raw_date_trunc(sql)
+        assert result == "SELECT DATEADD(week, DATEDIFF(week, -1, ts), -1) FROM t"
+
+    def test_unknown_grain_left_unchanged(self):
+        """An unrecognised grain is left as-is so Kusto surfaces the error."""
+        sql = "SELECT date_trunc('decade', ts) FROM t"
+        assert _translate_raw_date_trunc(sql) == sql
+
+    def test_sql_without_date_trunc_returned_unchanged(self):
+        sql = "SELECT id, name FROM users WHERE active = 1"
+        assert _translate_raw_date_trunc(sql) == sql
+
+    def test_nested_date_trunc_outer_only_translated(self):
+        """Nested date_trunc — only the outer call is translated; inner remains as-is.
+
+        This is a known limitation of the single-pass scanner. In practice, nesting
+        date_trunc calls is not a valid SQL pattern in analytics SQL.
+        """
+        sql = "SELECT date_trunc('day', date_trunc('hour', ts)) FROM t"
+        result = _translate_raw_date_trunc(sql)
+        assert "DATEADD(day" in result
+        assert "date_trunc('hour', ts)" in result
+
+
+class TestKustoSqlDialectDoExecute:
+    """KustoSqlHttpsDialect.do_execute must translate date_trunc before the cursor sees the SQL."""
+
+    def _dialect(self) -> KustoSqlHttpsDialect:
+        return KustoSqlHttpsDialect()
+
+    def test_date_trunc_translated_before_cursor(self):
+        cursor = MagicMock()
+        self._dialect().do_execute(
+            cursor, "SELECT date_trunc('day', ts) FROM t", [], context=None
+        )
+        cursor.execute.assert_called_once()
+        received_sql: str = cursor.execute.call_args[0][0]
+        assert "DATEADD(day" in received_sql
+        assert "date_trunc(" not in received_sql.lower()
+
+    def test_parameters_forwarded_unchanged(self):
+        cursor = MagicMock()
+        params = {"id": 42}
+        self._dialect().do_execute(cursor, "SELECT id FROM t", params, context=None)
+        cursor.execute.assert_called_once_with("SELECT id FROM t", params)
+
+    def test_sql_without_date_trunc_forwarded_unchanged(self):
+        cursor = MagicMock()
+        sql = "SELECT id, name FROM users WHERE active = 1"
+        self._dialect().do_execute(cursor, sql, [], context=None)
+        cursor.execute.assert_called_once_with(sql, [])

--- a/tests/unit/test_dialect_sql.py
+++ b/tests/unit/test_dialect_sql.py
@@ -67,6 +67,31 @@ def test_boolean_filter_full_query():
     assert "true" not in sql.lower()
 
 
+class TestIlikeLowerFolding:
+    """Kusto's LIKE pattern must be a string literal (OTR0001) and LIKE on a
+    column is case-sensitive, so the stock ILIKE form lower(x) LIKE lower(y)
+    must keep its left lower() but fold the right one into a lowered literal.
+    """
+
+    def test_lower_literal_folds(self):
+        """Mirrors the Superset filter-search query from the bug report."""
+        sql = "SELECT Name FROM t WHERE lower(Name) LIKE lower('%ФрЕш%')"
+        expected = "SELECT Name FROM t WHERE lower(Name) LIKE '%фреш%'"
+        assert _translate_raw_functions(sql) == expected
+
+    def test_lower_of_column_is_left_alone(self):
+        """lower(column) is valid Kusto; only constants can fold."""
+        sql = "SELECT lower(Name) FROM t WHERE lower(Name) = 'x'"
+        assert _translate_raw_functions(sql) == sql
+
+    def test_lower_with_non_literal_expression_is_left_alone(self):
+        sql = "SELECT 1 WHERE lower('a' + Name) = 'ab'"
+        assert _translate_raw_functions(sql) == sql
+
+    def test_folded_literal_keeps_quote_escapes(self):
+        assert _translate_raw_functions("lower('О''Хара')") == "'о''хара'"
+
+
 class TestOrderByWithoutLimit:
     """Kusto rejects ORDER BY in a nested SELECT that has no TOP; top level is fine."""
 
@@ -441,6 +466,16 @@ class TestCursorDateTruncTranslation:
         sql = "SELECT id, name FROM users WHERE active = 1"
         cursor.execute(sql)
         assert client.execute.call_args[0][1] == sql
+
+    def test_bound_ilike_pattern_folds_after_parameters(self):
+        """Parameters land first, then the rewrite, so a bound pattern can fold."""
+        cursor, client = self._cursor()
+        cursor.execute(
+            "SELECT Name FROM t WHERE lower(Name) LIKE lower(%(pat)s)",
+            {"pat": "%ФрЕш%"},
+        )
+        received_sql = client.execute.call_args[0][1]
+        assert received_sql == "SELECT Name FROM t WHERE lower(Name) LIKE '%фреш%'"
 
     def test_kql_query_is_never_rewritten(self):
         """A KQL query is not T-SQL; DATEADD would be invalid there."""

--- a/tests/unit/test_dialect_sql.py
+++ b/tests/unit/test_dialect_sql.py
@@ -14,9 +14,11 @@ from sqlalchemy import (
     select,
 )
 
-from sqlalchemy_kusto.dbapi import Cursor, _translate_raw_date_trunc
+from sqlalchemy_kusto.dbapi import Cursor, _translate_raw_functions, is_tsql_query
 
 engine = create_engine("kustosql+https://localhost/testdb")
+
+DAY_TRUNCATIONS_IN_NESTED_MIX = 2
 
 metadata = MetaData()
 orders = Table(
@@ -162,7 +164,7 @@ class TestDateTruncCompiled:
 
 
 class TestTranslateRawDateTrunc:
-    """_translate_raw_date_trunc rewrites date_trunc() in a raw SQL string."""
+    """_translate_raw_functions rewrites unsupported calls in a raw SQL string."""
 
     @pytest.mark.parametrize(
         ("sql", "expected"),
@@ -209,17 +211,17 @@ class TestTranslateRawDateTrunc:
         ],
     )
     def test_translation(self, sql: str, expected: str):
-        assert _translate_raw_date_trunc(sql) == expected
+        assert _translate_raw_functions(sql) == expected
 
     def test_grain_capitalisation_normalised(self):
         for grain in ("Day", "DAY", "dAy"):
-            result = _translate_raw_date_trunc(
+            result = _translate_raw_functions(
                 f"SELECT date_trunc('{grain}', ts) FROM t"
             )
             assert "DATEADD(day," in result, f"failed for grain={grain!r}: {result}"
 
     def test_multiple_calls_in_one_query(self):
-        result = _translate_raw_date_trunc(
+        result = _translate_raw_functions(
             "SELECT date_trunc('day', a), date_trunc('hour', b) FROM t"
         )
         assert "DATEADD(day," in result
@@ -245,16 +247,146 @@ class TestTranslateRawDateTrunc:
         ],
     )
     def test_left_unchanged(self, sql: str):
-        assert _translate_raw_date_trunc(sql) == sql
+        assert _translate_raw_functions(sql) == sql
 
     def test_literal_next_to_a_real_call_is_preserved(self):
-        result = _translate_raw_date_trunc(
+        result = _translate_raw_functions(
             "SELECT date_trunc('day', ts) FROM t WHERE note = 'date_trunc(''day'', x)'"
         )
         assert result == (
             "SELECT DATEADD(day, DATEDIFF(day, 0, ts), 0) FROM t "
             "WHERE note = 'date_trunc(''day'', x)'"
         )
+
+
+class TestTranslateOtherFunctions:
+    """Calls Kusto does not implement, rewritten to the form it does.
+
+    Every shape here was taken from production SQLLab queries and its replacement
+    executed against the Kusto emulator.
+    """
+
+    @pytest.mark.parametrize(
+        ("sql", "expected"),
+        [
+            # T-SQL 2022 spelling, and the bare (unquoted) grain both analysts use
+            (
+                "SELECT DATETRUNC('hour', ts) FROM t",
+                "SELECT DATEADD(hour, DATEDIFF(hour, '2000-01-01', ts), '2000-01-01') FROM t",
+            ),
+            (
+                "SELECT DATETRUNC(month, ts) FROM t",
+                "SELECT DATEADD(month, DATEDIFF(month, 0, ts), 0) FROM t",
+            ),
+            # date_part in both spellings -> DATEPART, whose unit is bare in T-SQL
+            ("SELECT DATE_PART(hour, ts) FROM t", "SELECT DATEPART(hour, ts) FROM t"),
+            ("SELECT date_part('year', ts) FROM t", "SELECT DATEPART(year, ts) FROM t"),
+            # KQL habits that do not exist in T-SQL
+            (
+                "SELECT startofday(ts) FROM t",
+                "SELECT DATEADD(day, DATEDIFF(day, 0, ts), 0) FROM t",
+            ),
+            (
+                "SELECT startofmonth(ts) FROM t",
+                "SELECT DATEADD(month, DATEDIFF(month, 0, ts), 0) FROM t",
+            ),
+            (
+                "SELECT startofweek(ts) FROM t",  # KQL weeks start on Sunday
+                "SELECT DATEADD(week, DATEDIFF(week, -1, ts), -1) FROM t",
+            ),
+            # MySQL habits
+            ("SELECT IFNULL(a, 0) FROM t", "SELECT COALESCE(a, 0) FROM t"),
+            ("SELECT ifnull(a , 'x') FROM t", "SELECT COALESCE(a, 'x') FROM t"),
+            # DATE()/to_date() must drop the time: Kusto's CAST to DATE keeps it
+            (
+                "SELECT DATE(ts) FROM t",
+                "SELECT DATEADD(day, DATEDIFF(day, 0, ts), 0) FROM t",
+            ),
+            (
+                "SELECT date (ts) FROM t",  # whitespace before the paren
+                "SELECT DATEADD(day, DATEDIFF(day, 0, ts), 0) FROM t",
+            ),
+            (
+                "SELECT to_date(sale_date) FROM t",
+                "SELECT DATEADD(day, DATEDIFF(day, 0, sale_date), 0) FROM t",
+            ),
+        ],
+    )
+    def test_translation(self, sql: str, expected: str):
+        assert _translate_raw_functions(sql) == expected
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # no exact equivalent exists: let Kusto say so instead of guessing
+            "SELECT DATE_FORMAT(ts, '%Y-%m-%d') FROM t",
+            "SELECT FORMAT(ts, 'yyyy-MM') FROM t",
+            "SELECT TRY_CAST(note AS INT) FROM t",
+            "SELECT JSON_VALUE(payload, '$.a') FROM t",
+            # forms Kusto already understands must not be touched
+            "SELECT CONVERT(DATE, ts) FROM t",
+            "SELECT CAST(ts AS DATE) FROM t",
+            "SELECT DATEADD(day, 1, ts) FROM t",
+            "SELECT DATEPART(year, ts) FROM t",
+            # a name that merely ends with a translated one
+            "SELECT my_date(ts), sale.date(x) FROM t",
+            # wrong arity: not the function we know
+            "SELECT date(ts, 'HOUR') FROM t",
+            "SELECT ifnull(a) FROM t",
+            # a column called date is not a call
+            "SELECT date, to_date FROM t ORDER BY date",
+        ],
+    )
+    def test_left_unchanged(self, sql: str):
+        assert _translate_raw_functions(sql) == sql
+
+    def test_nested_mix_is_translated_throughout(self):
+        result = _translate_raw_functions(
+            "SELECT IFNULL(date_trunc('day', startofmonth(ts)), DATE(other)) FROM t"
+        )
+        assert "COALESCE(" in result
+        # two day-truncations: date_trunc('day', ...) and DATE(other)
+        assert result.count("DATEADD(day") == DAY_TRUNCATIONS_IN_NESTED_MIX
+        assert "DATEADD(month" in result
+        assert "ifnull" not in result.lower()
+        assert "startofmonth" not in result.lower()
+
+
+class TestIsTsqlQuery:
+    """The query language is chosen from the text; a CTE is T-SQL, not KQL."""
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT 1",
+            "  select 1",
+            "WITH t AS (SELECT 1 x) SELECT x FROM t",
+            "with t as (select 1 x) select x from t",
+            ";WITH t AS (SELECT 1 x) SELECT x FROM t",
+            "-- a comment\nSELECT 1",
+            "/* header */ WITH t AS (SELECT 1 x) SELECT x FROM t",
+        ],
+    )
+    def test_recognised_as_tsql(self, sql: str):
+        assert is_tsql_query(sql) is True
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "events | take 10",
+            "let x = 1; print x",
+            ".show tables",
+            "print now()",
+            "withdrawals | count",  # starts with "with" but is not a CTE
+        ],
+    )
+    def test_recognised_as_kql(self, sql: str):
+        assert is_tsql_query(sql) is False
+
+    def test_long_comment_header_is_linear(self):
+        """A repeated-alternation regex here used to backtrack catastrophically."""
+        sql = "\n".join(f"-- note {i}" for i in range(2000)) + "\nevents | take 1"
+        assert is_tsql_query(sql) is False
 
 
 class TestCursorDateTruncTranslation:

--- a/tests/unit/test_dialect_sql.py
+++ b/tests/unit/test_dialect_sql.py
@@ -340,6 +340,33 @@ class TestTranslateOtherFunctions:
     def test_left_unchanged(self, sql: str):
         assert _translate_raw_functions(sql) == sql
 
+    @pytest.mark.parametrize(
+        ("sql", "expected"),
+        [
+            # an apostrophe in a comment used to be read as a string literal, which
+            # swallowed the rest of the query and left the real call untranslated
+            (
+                "-- don't ask\nSELECT date_trunc('day', ts) FROM t",
+                "-- don't ask\nSELECT DATEADD(day, DATEDIFF(day, 0, ts), 0) FROM t",
+            ),
+            (
+                "/* it's a header */ SELECT date_trunc('day', ts) FROM t",
+                "/* it's a header */ SELECT DATEADD(day, DATEDIFF(day, 0, ts), 0) FROM t",
+            ),
+            # a call inside a comment stays a comment, untouched
+            (
+                "SELECT 1 -- date_trunc('day', x)\nFROM t",
+                "SELECT 1 -- date_trunc('day', x)\nFROM t",
+            ),
+            (
+                "SELECT /* date_trunc('day', x) */ 1 FROM t",
+                "SELECT /* date_trunc('day', x) */ 1 FROM t",
+            ),
+        ],
+    )
+    def test_comments_are_opaque(self, sql: str, expected: str):
+        assert _translate_raw_functions(sql) == expected
+
     def test_nested_mix_is_translated_throughout(self):
         result = _translate_raw_functions(
             "SELECT IFNULL(date_trunc('day', startofmonth(ts)), DATE(other)) FROM t"

--- a/tests/unit/test_dialect_sql.py
+++ b/tests/unit/test_dialect_sql.py
@@ -1,15 +1,20 @@
-from __future__ import annotations
-from sqlalchemy import Boolean, Column, Integer, MetaData, Table, create_engine, select
-
 from unittest.mock import MagicMock
 
-from sqlalchemy import DateTime, func
+import pytest
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    Table,
+    create_engine,
+    exc,
+    func,
+    select,
+)
 
-from sqlalchemy_kusto.dialect_sql import KustoSqlHttpsDialect, _translate_raw_date_trunc
-
-engine = create_engine("kustosql+https://localhost/testdb")
-
-
+from sqlalchemy_kusto.dbapi import Cursor, _translate_raw_date_trunc
 
 engine = create_engine("kustosql+https://localhost/testdb")
 
@@ -23,12 +28,18 @@ orders = Table(
 )
 
 
+def _compile(query, bind=engine) -> str:
+    return str(query.compile(bind, compile_kwargs={"literal_binds": True})).replace(
+        "\n", " "
+    )
+
+
 def test_boolean_false_renders_as_zero():
     """Kusto T-SQL does not support `false`/`true` literals; they must be 1/0."""
     query = select(orders.c.TotalAmount).where(
         orders.c.IsCorporateOrder == False  # noqa: E712
     )
-    sql = str(query.compile(engine, compile_kwargs={"literal_binds": True}))
+    sql = _compile(query)
     assert "false" not in sql.lower()
     assert "0" in sql
 
@@ -37,7 +48,7 @@ def test_boolean_true_renders_as_one():
     query = select(orders.c.TotalAmount).where(
         orders.c.IsCorporateOrder == True  # noqa: E712
     )
-    sql = str(query.compile(engine, compile_kwargs={"literal_binds": True}))
+    sql = _compile(query)
     assert "true" not in sql.lower()
     assert "1" in sql
 
@@ -49,242 +60,228 @@ def test_boolean_filter_full_query():
         .where(orders.c.IsCorporateOrder == False)  # noqa: E712
         .group_by(orders.c.TotalAmount)
     )
-    sql = str(query.compile(engine, compile_kwargs={"literal_binds": True}))
+    sql = _compile(query)
     assert "false" not in sql.lower()
     assert "true" not in sql.lower()
 
-def _compile(query) -> str:
-    return str(query.compile(engine, compile_kwargs={"literal_binds": True})).replace("\n", " ")
-
 
 class TestOrderByWithoutLimit:
+    """Kusto drops ORDER BY unless the same SELECT carries a TOP."""
+
+    events = Table("events", MetaData(), Column("score", Integer))
+
     def test_order_by_without_limit_inserts_top_fallback(self):
-        t = Table("events", MetaData(), Column("score", Integer))
-        query = select([t.c.score]).order_by(t.c.score.desc())
-        sql = _compile(query)
-        assert "TOP" in sql
+        sql = _compile(
+            select([self.events.c.score]).order_by(self.events.c.score.desc())
+        )
+        assert "TOP 500000" in sql
         assert "ORDER BY" in sql
 
     def test_order_by_with_limit_uses_limit_not_double_top(self):
-        t = Table("events", MetaData(), Column("score", Integer))
-        query = select([t.c.score]).order_by(t.c.score.desc()).limit(10)
+        query = (
+            select([self.events.c.score]).order_by(self.events.c.score.desc()).limit(10)
+        )
         sql = _compile(query)
         assert sql.count("TOP") == 1
         assert "TOP 10" in sql
 
     def test_select_without_order_by_no_extra_top(self):
-        t = Table("events", MetaData(), Column("score", Integer))
-        query = select([t.c.score])
-        sql = _compile(query)
-        assert "TOP" not in sql
+        assert "TOP" not in _compile(select([self.events.c.score]))
+
+    def test_inner_order_by_survives_outer_limit(self):
+        """Superset wraps the query; the inner ORDER BY needs its own TOP."""
+        inner = (
+            select([self.events.c.score])
+            .order_by(self.events.c.score.desc())
+            .alias("v")
+        )
+        sql = _compile(select([inner.c.score]).limit(100))
+        assert "TOP 500000" in sql
+        assert "TOP 100" in sql
+        assert "ORDER BY" in sql
 
     def test_top_fallback_value_is_configurable(self):
-        custom_engine = create_engine("kustosql+https://localhost/testdb", connect_args={})
-        custom_engine.dialect.max_top_n = 999
-        t = Table("events", MetaData(), Column("score", Integer))
-        query = select([t.c.score]).order_by(t.c.score.desc())
-        sql = str(query.compile(custom_engine, compile_kwargs={"literal_binds": True}))
-        assert "TOP 999" in sql
+        """max_top_n must be settable the way callers actually set it."""
+        custom_engine = create_engine(
+            "kustosql+https://localhost/testdb", max_top_n=999
+        )
+        query = select([self.events.c.score]).order_by(self.events.c.score.desc())
+        assert "TOP 999" in _compile(query, custom_engine)
 
 
-class TestDateTrunc:
+class TestDateTruncCompiled:
+    """func.date_trunc() goes through the dialect hook."""
+
+    events = Table("events", MetaData(), Column("ts", DateTime))
+
     def _query(self, grain: str) -> str:
-        t = Table("events", MetaData(), Column("ts", DateTime))
-        query = select([func.date_trunc(grain, t.c.ts)])
-        return _compile(query)
+        return _compile(select([func.date_trunc(grain, self.events.c.ts)]))
 
-    def test_date_trunc_day(self):
-        sql = self._query("day")
-        assert "DATEADD(day" in sql
-        assert "DATEDIFF(day" in sql
-
-    def test_date_trunc_month(self):
-        sql = self._query("month")
-        assert "DATEADD(month" in sql
-        assert "DATEDIFF(month" in sql
-
-    def test_date_trunc_year(self):
-        sql = self._query("year")
-        assert "DATEADD(year" in sql
-        assert "DATEDIFF(year" in sql
-
-    def test_date_trunc_hour(self):
-        sql = self._query("hour")
-        assert "DATEADD(hour" in sql
-        assert "DATEDIFF(hour" in sql
-
-    def test_date_trunc_minute(self):
-        sql = self._query("minute")
-        assert "DATEADD(minute" in sql
-        assert "DATEDIFF(minute" in sql
-
-    def test_date_trunc_week(self):
-        sql = self._query("week")
-        # Must use the DATEADD(day,-1,...) shift for Monday-based ISO weeks
-        assert "DATEADD(week" in sql
-        assert "DATEDIFF(week" in sql
-        assert "DATEADD(day, -1," in sql
-
-    def test_date_trunc_week_sun(self):
-        sql = self._query("week_sun")
-        # Sunday-based: uses epoch -1 (1899-12-31 = Sunday), no day shift
-        assert "DATEADD(week" in sql
-        assert "DATEDIFF(week" in sql
-        assert ", -1," in sql or ", -1)" in sql
-        assert "DATEADD(day, -1," not in sql
-
-    def test_date_trunc_quarter(self):
-        sql = self._query("quarter")
-        assert "DATEADD(quarter" in sql
-        assert "DATEDIFF(quarter" in sql
-
-    def test_date_trunc_not_passed_through_verbatim(self):
-        sql = self._query("day")
+    @pytest.mark.parametrize(
+        ("grain", "part"),
+        [
+            ("second", "second"),
+            ("minute", "minute"),
+            ("hour", "hour"),
+            ("day", "day"),
+            ("month", "month"),
+            ("quarter", "quarter"),
+            ("year", "year"),
+        ],
+    )
+    def test_grain_maps_to_datepart(self, grain: str, part: str):
+        sql = self._query(grain)
+        assert f"DATEADD({part}," in sql
+        assert f"DATEDIFF({part}," in sql
         assert "date_trunc(" not in sql.lower()
 
-    def test_date_trunc_minute_uses_safe_epoch(self):
-        sql = self._query("minute")
-        assert "2000-01-01" in sql
+    def test_week_is_monday_based(self):
+        sql = self._query("week")
+        assert "DATEADD(day, -1," in sql  # ISO week shift
+        assert ", 0," in sql
 
-    def test_date_trunc_day_uses_zero_epoch(self):
-        sql = self._query("day")
-        assert ", 0," in sql or ", 0)" in sql
+    def test_week_sun_uses_sunday_epoch(self):
+        sql = self._query("week_sun")
+        assert "DATEADD(week," in sql
+        assert ", -1," in sql
+        assert "DATEADD(day, -1," not in sql
+
+    def test_sub_day_grain_uses_safe_epoch(self):
+        assert "2000-01-01" in self._query("minute")
+
+    def test_grain_is_case_insensitive(self):
+        assert "DATEADD(day," in self._query("DAY")
+
+    def test_unsupported_grain_fails_loudly(self):
+        with pytest.raises(exc.CompileError):
+            self._query("decade")
 
 
 class TestTranslateRawDateTrunc:
     """_translate_raw_date_trunc rewrites date_trunc() in a raw SQL string."""
 
-    def test_day_grain(self):
-        sql = "SELECT date_trunc('day', event_time) FROM events"
-        assert _translate_raw_date_trunc(sql) == (
-            "SELECT DATEADD(day, DATEDIFF(day, 0, event_time), 0) FROM events"
-        )
-
-    def test_month_grain(self):
-        sql = "SELECT date_trunc('month', ts) FROM t"
-        result = _translate_raw_date_trunc(sql)
-        assert result == "SELECT DATEADD(month, DATEDIFF(month, 0, ts), 0) FROM t"
-
-    def test_year_grain(self):
-        sql = "SELECT date_trunc('year', ts) FROM t"
-        result = _translate_raw_date_trunc(sql)
-        assert result == "SELECT DATEADD(year, DATEDIFF(year, 0, ts), 0) FROM t"
-
-    def test_week_grain(self):
-        sql = "SELECT date_trunc('week', ts) FROM t"
-        result = _translate_raw_date_trunc(sql)
-        assert result == "SELECT DATEADD(week, DATEDIFF(week, 0, DATEADD(day, -1, ts)), 0) FROM t"
-
-    def test_quarter_grain(self):
-        sql = "SELECT date_trunc('quarter', ts) FROM t"
-        result = _translate_raw_date_trunc(sql)
-        assert result == "SELECT DATEADD(quarter, DATEDIFF(quarter, 0, ts), 0) FROM t"
-
-    def test_hour_grain_uses_safe_epoch(self):
-        """Sub-day grains must use '2000-01-01' to avoid DATEDIFF integer overflow."""
-        sql = "SELECT date_trunc('hour', ts) FROM logs"
-        result = _translate_raw_date_trunc(sql)
-        assert result == (
-            "SELECT DATEADD(hour, DATEDIFF(hour, '2000-01-01', ts), '2000-01-01') FROM logs"
-        )
-
-    def test_minute_grain_uses_safe_epoch(self):
-        sql = "SELECT date_trunc('minute', ts) FROM logs"
-        result = _translate_raw_date_trunc(sql)
-        assert "DATEADD(minute" in result
-        assert "'2000-01-01'" in result
-
-    def test_second_grain_uses_safe_epoch(self):
-        sql = "SELECT date_trunc('second', ts) FROM logs"
-        result = _translate_raw_date_trunc(sql)
-        assert "DATEADD(second" in result
-        assert "'2000-01-01'" in result
-
-    def test_milliseconds_grain_maps_to_millisecond(self):
-        """'milliseconds' (plural) maps to T-SQL 'millisecond' (singular)."""
-        sql = "SELECT date_trunc('milliseconds', ts) FROM logs"
-        result = _translate_raw_date_trunc(sql)
-        assert "DATEADD(millisecond," in result
-        assert "'2000-01-01'" in result
-
-    def test_microseconds_grain_maps_to_millisecond(self):
-        """'microseconds' maps to 'millisecond' — T-SQL has no microsecond datepart."""
-        sql = "SELECT date_trunc('microseconds', ts) FROM logs"
-        result = _translate_raw_date_trunc(sql)
-        assert "DATEADD(millisecond," in result
+    @pytest.mark.parametrize(
+        ("sql", "expected"),
+        [
+            (
+                "SELECT date_trunc('day', event_time) FROM events",
+                "SELECT DATEADD(day, DATEDIFF(day, 0, event_time), 0) FROM events",
+            ),
+            (
+                "SELECT date_trunc('month', ts) FROM t",
+                "SELECT DATEADD(month, DATEDIFF(month, 0, ts), 0) FROM t",
+            ),
+            (
+                "SELECT date_trunc('year', ts) FROM t",
+                "SELECT DATEADD(year, DATEDIFF(year, 0, ts), 0) FROM t",
+            ),
+            (
+                "SELECT date_trunc('quarter', ts) FROM t",
+                "SELECT DATEADD(quarter, DATEDIFF(quarter, 0, ts), 0) FROM t",
+            ),
+            (
+                "SELECT date_trunc('week', ts) FROM t",
+                "SELECT DATEADD(week, DATEDIFF(week, 0, DATEADD(day, -1, ts)), 0) FROM t",
+            ),
+            (
+                "SELECT date_trunc('week_sun', ts) FROM t",
+                "SELECT DATEADD(week, DATEDIFF(week, -1, ts), -1) FROM t",
+            ),
+            (
+                "SELECT date_trunc('hour', ts) FROM logs",
+                "SELECT DATEADD(hour, DATEDIFF(hour, '2000-01-01', ts), '2000-01-01') FROM logs",
+            ),
+            (
+                # nested parentheses in the expression must survive intact
+                "SELECT date_trunc('day', CAST(ts AS DATETIME)) FROM logs",
+                "SELECT DATEADD(day, DATEDIFF(day, 0, CAST(ts AS DATETIME)), 0) FROM logs",
+            ),
+            (
+                # nesting is translated inside out
+                "SELECT date_trunc('day', date_trunc('hour', ts)) FROM t",
+                "SELECT DATEADD(day, DATEDIFF(day, 0, DATEADD(hour, "
+                "DATEDIFF(hour, '2000-01-01', ts), '2000-01-01')), 0) FROM t",
+            ),
+        ],
+    )
+    def test_translation(self, sql: str, expected: str):
+        assert _translate_raw_date_trunc(sql) == expected
 
     def test_grain_capitalisation_normalised(self):
-        """Grain is case-insensitive — 'Day' and 'DAY' must work like 'day'."""
         for grain in ("Day", "DAY", "dAy"):
-            sql = f"SELECT date_trunc('{grain}', ts) FROM t"
-            result = _translate_raw_date_trunc(sql)
-            assert "DATEADD(day" in result, f"Failed for grain={grain!r}: {result}"
-
-    def test_nested_parens_in_expr(self):
-        """Expressions containing parentheses must be preserved intact."""
-        sql = "SELECT date_trunc('day', CAST(ts AS DATETIME)) FROM logs"
-        result = _translate_raw_date_trunc(sql)
-        assert result == (
-            "SELECT DATEADD(day, DATEDIFF(day, 0, CAST(ts AS DATETIME)), 0) FROM logs"
-        )
+            result = _translate_raw_date_trunc(
+                f"SELECT date_trunc('{grain}', ts) FROM t"
+            )
+            assert "DATEADD(day," in result, f"failed for grain={grain!r}: {result}"
 
     def test_multiple_calls_in_one_query(self):
-        """Every occurrence is translated."""
-        sql = "SELECT date_trunc('day', a), date_trunc('hour', b) FROM t"
-        result = _translate_raw_date_trunc(sql)
-        assert "DATEADD(day" in result
-        assert "DATEADD(hour" in result
+        result = _translate_raw_date_trunc(
+            "SELECT date_trunc('day', a), date_trunc('hour', b) FROM t"
+        )
+        assert "DATEADD(day," in result
+        assert "DATEADD(hour," in result
         assert "date_trunc(" not in result.lower()
 
-    def test_week_sun_grain(self):
-        """week_sun uses epoch -1 (Sunday) with no day shift."""
-        sql = "SELECT date_trunc('week_sun', ts) FROM t"
-        result = _translate_raw_date_trunc(sql)
-        assert result == "SELECT DATEADD(week, DATEDIFF(week, -1, ts), -1) FROM t"
-
-    def test_unknown_grain_left_unchanged(self):
-        """An unrecognised grain is left as-is so Kusto surfaces the error."""
-        sql = "SELECT date_trunc('decade', ts) FROM t"
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # a value that merely looks like a call must not be rewritten
+            "SELECT * FROM t WHERE note = 'date_trunc(''day'', x)'",
+            "SELECT * FROM t WHERE note = \"date_trunc('day', x)\"",
+            # sub-second grains have no overflow-free form, so they are not supported
+            "SELECT date_trunc('milliseconds', ts) FROM logs",
+            "SELECT date_trunc('microseconds', ts) FROM logs",
+            # unrecognised grain: leave it for Kusto to reject
+            "SELECT date_trunc('decade', ts) FROM t",
+            # malformed calls stay as they are
+            "SELECT date_trunc('day' ts) FROM t",
+            "SELECT date_trunc('day', ts FROM t",
+            # nothing to do
+            "SELECT id, name FROM users WHERE active = 1",
+        ],
+    )
+    def test_left_unchanged(self, sql: str):
         assert _translate_raw_date_trunc(sql) == sql
 
-    def test_sql_without_date_trunc_returned_unchanged(self):
-        sql = "SELECT id, name FROM users WHERE active = 1"
-        assert _translate_raw_date_trunc(sql) == sql
-
-    def test_nested_date_trunc_outer_only_translated(self):
-        """Nested date_trunc — only the outer call is translated; inner remains as-is.
-
-        This is a known limitation of the single-pass scanner. In practice, nesting
-        date_trunc calls is not a valid SQL pattern in analytics SQL.
-        """
-        sql = "SELECT date_trunc('day', date_trunc('hour', ts)) FROM t"
-        result = _translate_raw_date_trunc(sql)
-        assert "DATEADD(day" in result
-        assert "date_trunc('hour', ts)" in result
+    def test_literal_next_to_a_real_call_is_preserved(self):
+        result = _translate_raw_date_trunc(
+            "SELECT date_trunc('day', ts) FROM t WHERE note = 'date_trunc(''day'', x)'"
+        )
+        assert result == (
+            "SELECT DATEADD(day, DATEDIFF(day, 0, ts), 0) FROM t "
+            "WHERE note = 'date_trunc(''day'', x)'"
+        )
 
 
 class TestCursorDateTruncTranslation:
-    """Cursor.execute must translate date_trunc before sending SQL to Kusto."""
+    """Cursor.execute translates T-SQL only, and leaves KQL alone."""
 
-    def _cursor(self):
-        from sqlalchemy_kusto.dbapi import Cursor
-
+    @staticmethod
+    def _cursor() -> tuple[Cursor, MagicMock]:
         client = MagicMock()
         response = MagicMock()
-        response.primary_results = [MagicMock(columns=[], **{"__iter__": lambda s: iter([])})]
+        response.primary_results = [
+            MagicMock(columns=[], **{"__iter__": lambda _: iter([])})
+        ]
         client.execute.return_value = response
         return Cursor(client, "testdb"), client
 
     def test_date_trunc_translated_before_kusto(self):
         cursor, client = self._cursor()
         cursor.execute("SELECT date_trunc('day', ts) FROM t")
-        received_sql: str = client.execute.call_args[0][1]
-        assert "DATEADD(day" in received_sql
+        received_sql = client.execute.call_args[0][1]
+        assert "DATEADD(day," in received_sql
         assert "date_trunc(" not in received_sql.lower()
 
     def test_sql_without_date_trunc_forwarded_unchanged(self):
         cursor, client = self._cursor()
         sql = "SELECT id, name FROM users WHERE active = 1"
         cursor.execute(sql)
-        received_sql: str = client.execute.call_args[0][1]
-        assert received_sql.rstrip() == sql
+        assert client.execute.call_args[0][1] == sql
+
+    def test_kql_query_is_never_rewritten(self):
+        """A KQL query is not T-SQL; DATEADD would be invalid there."""
+        cursor, client = self._cursor()
+        kql = "events | extend d = date_trunc('day', ts) | take 10"
+        cursor.execute(kql)
+        assert client.execute.call_args[0][1] == kql


### PR DESCRIPTION
## Summary

Makes the T-SQL dialect usable from Superset charts and SQL Lab against Kusto. Running in Dodo production Superset for about a month (the Superset fork pins this branch).

Tickets: 61156998 (date_trunc), 68302686 (ILIKE).

### `date_trunc` (61156998)
- `func.date_trunc(grain, col)` compiles to `DATEADD(part, DATEDIFF(part, epoch, x), epoch)` on the `kustosql` dialect. Unsupported grains raise `CompileError`.
- Raw `date_trunc('grain', x)` typed in SQL Lab is rewritten to the same form in `Cursor.execute()`, so it also covers the path where Superset bypasses the dialect.
- `week` is Monday-based like PostgreSQL. Sub-day grains use a 2000-01-01 epoch to stay inside int32 (`second` therefore works for years 1932–2068).

### Other functions Kusto's T-SQL emulation lacks
Rewritten in the same pass, each verified against the Kusto emulator: `datetrunc`, `date_part` → `DATEPART`, `ifnull` → `COALESCE`, `startofday/week/month/year`, `to_date`, `date` (truncate to day). Anything without an exact equivalent (`FORMAT`, `TRY_CAST`, `JSON_VALUE`, …) is left alone so Kusto reports it.

The rewriter is a linear scanner: string literals and SQL comments are opaque, nested calls are handled recursively, unbalanced input is passed through untouched. KQL queries are never rewritten.

### ILIKE (68302686)
Kusto requires a `LIKE` pattern to be a string literal, but SQLAlchemy's `ilike` compiles to `lower(x) LIKE lower('%p%')`. `lower('literal')` is folded to the lowercased literal.

### Query language detection
`is_tsql_query()` now treats a leading `WITH` as T-SQL (CTEs used to be sent as KQL and fail), skips leading comments, semicolons and whitespace, and requires a whole-word `select`/`with`.

### Nested `ORDER BY` without `LIMIT`
Kusto rejects `ORDER BY` inside a subquery unless it carries `TOP`. Superset's `WRAP_SQL` limit method produces exactly that shape, so a nested `ORDER BY` without its own limit gets `TOP {max_top_n}` (default 500 000, configurable via `create_engine(url, max_top_n=...)` / Superset engine parameters). Top-level `ORDER BY` is unaffected.

### Test infrastructure
- `kustosql+http://` dialect for the Kusto emulator (plain HTTP, no auth, custom port).
- `make emulator` / `make emulator-stop`; integration tests run against the emulator by default and are skipped when it is unreachable. `KUSTO_URL` still targets a real cluster.
- CI now runs the integration tests against the emulator.
- README section on running tests.

## Verification
- Unit: 186 passed.
- Integration against `kustainer-linux`: 51 passed, 1 skipped (auth error test, not applicable to the emulator).
- Week truncation checked for every weekday; ruff and black unchanged vs `main`.

## Known limits
- `date_trunc('second', …)` overflows outside 1932–2068.
- `lower(N'…')` is not folded.
- An apostrophe inside a `[bracketed identifier]` is read as a string opener.

## Release
Bumps the version to **3.2.0** (minor: new features, no breaking changes for existing `kustosql+https` / `kustokql+https` users). After merge: tag `3.2.0`, GitHub release, `make release` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
